### PR TITLE
feat(knop): implement first local add-reference slice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,7 @@
 - Primary developer guidance for this repository is in: `documentation/notes/wd.general-guidance.md`
   - Read that note before proposing or applying changes or formulating new tasks
 
+- Do not rename `wd.task.*` notes to `wd.completed.*` unless the user explicitly asks you to.
+  - The human may prefer to do the task-note rename manually after review.
+
 - DON'T BE A PUSHOVER. Humans are usually at-least-partially wrong about things. Effective humans want reasoned push-back.

--- a/documentation/notes/wd.codebase-overview.md
+++ b/documentation/notes/wd.codebase-overview.md
@@ -12,7 +12,7 @@ created: 1773673181726
   semantic operations and domain rules
   mesh create, knop create, integrate, version, validate, generate, extract, weave
   request/result types shared by all callers
-  current carried slices: `mesh create` request validation/support-artifact rendering, `knop create` planning over an existing mesh inventory, the first narrow `integrate` planning slice for `05-alice-knop-created-woven` -> `06-alice-bio-integrated`, and the first two narrow `weave` planning slices for `04-alice-knop-created` -> `05-alice-knop-created-woven` and `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`
+  current carried slices: `mesh create` request validation/support-artifact rendering, `knop create` planning over an existing mesh inventory, the first narrow `integrate` planning slice for `05-alice-knop-created-woven` -> `06-alice-bio-integrated`, the first narrow `knop add-reference` planning slice for `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced`, and the first two narrow `weave` planning slices for `04-alice-knop-created` -> `05-alice-knop-created-woven` and `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`
 
 ### runtime
   local workspace execution
@@ -20,7 +20,7 @@ created: 1773673181726
   job execution primitives, but not HTTP
   includes first-pass Deno-native structured operational and audit logging
   persistent config direction is RDF, probably JSON-LD, and should remain queryable via SPARQL
-  current carried slices: local filesystem materialization for `mesh create`, `knop create`, the first local `integrate` pass over an existing workspace payload file, and the first two local `weave` passes over an existing workspace with a shared runtime ResourcePage renderer seam
+  current carried slices: local filesystem materialization for `mesh create`, `knop create`, `knop add-reference`, the first local `integrate` pass over an existing workspace payload file, and the first two local `weave` passes over an existing workspace with a shared runtime ResourcePage renderer seam
   current logging slice: narrow Kato-inspired `LogRecord` / sink / `StructuredLogger` / `AuditLogger` JSONL layer
 
 ### daemon
@@ -35,8 +35,8 @@ created: 1773673181726
   remote mode: talks to daemon over HTTP
   local mode: calls core/runtime directly
   no separate semantic logic
-  current carried slices: top-level local `weave`, plus local `weave mesh create`, `weave knop create`, and `weave integrate`, all over shared core/runtime
-  current acceptance paths: black-box CLI execution checked against the `02-mesh-created`, `04-alice-knop-created`, `05-alice-knop-created-woven`, `06-alice-bio-integrated`, and `07-alice-bio-integrated-woven` Accord manifest scopes
+  current carried slices: top-level local `weave`, plus local `weave mesh create`, `weave knop create`, `weave knop add-reference`, and `weave integrate`, all over shared core/runtime
+  current acceptance paths: black-box CLI execution checked against the `02-mesh-created`, `04-alice-knop-created`, `05-alice-knop-created-woven`, `06-alice-bio-integrated`, `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` Accord manifest scopes
 
 ### web app
   browser client of daemon
@@ -53,8 +53,10 @@ created: 1773673181726
 - The second carried implementation slice is the local `knop create` path matching the settled Alice Bio `03-mesh-created-woven` -> `04-alice-knop-created` fixture state.
 - The third carried implementation slice is the local `integrate` path matching the settled Alice Bio `05-alice-knop-created-woven` -> `06-alice-bio-integrated` fixture state.
 - The fourth carried implementation slice is the local `weave` path matching the settled Alice Bio `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven` fixture state.
+- The fifth carried implementation slice is the local `knop add-reference` path matching the settled Alice Bio `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` fixture state.
 - The current carried `weave` slices are the local `04-alice-knop-created` -> `05-alice-knop-created-woven` and `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven` paths, including first-history creation for Knop support artifacts, first payload-artifact history creation, and minimal generated HTML pages rendered through a shared runtime page seam.
 - `mesh create` now has a manifest-scoped black-box CLI acceptance test and thin framework example payloads.
 - `knop create` now resolves `meshBase` from existing mesh metadata, creates the first Knop support artifacts, and has a manifest-scoped black-box CLI acceptance test.
+- `knop add-reference` now resolves `meshBase` from existing mesh metadata, requires an explicit local `referenceRole`, creates the first Knop-owned `ReferenceCatalog` working file, updates the existing Knop inventory, and has manifest-scoped black-box CLI acceptance coverage for `08-alice-bio-referenced`.
 - `integrate` now resolves a local source path or `file:` URL into a mesh-relative working file path, creates the first payload-Knop support artifacts, updates MeshInventory, and has manifest-scoped black-box CLI acceptance coverage together with thin framework examples.
 - `weave` now runs as the top-level local CLI action, versions the first Alice Knop support artifacts and the first Alice Bio payload history surface, advances MeshInventory where the public current surface changed, and has manifest-scoped black-box CLI acceptance coverage through `07`.

--- a/documentation/notes/wd.completed.2026.2026-04-04-alice-bio-referenced.md
+++ b/documentation/notes/wd.completed.2026.2026-04-04-alice-bio-referenced.md
@@ -66,7 +66,7 @@ That is enough to prove:
 
 ### Existing spec posture
 
-This task should add a dedicated `wd.spec.*` note before implementation.
+This task should use a dedicated [[wd.spec.2026-04-04-knop-add-reference-behavior]] note before implementation.
 
 Unlike the carried `weave` slices, there is no existing broad behavior note that already covers the first non-woven reference-catalog operation. The task should use [[ont.reference-links]] as the detailed ontology companion, but it should still define a narrow Weave-facing behavior spec for the first local or in-process path.
 
@@ -82,32 +82,38 @@ The settled `07` -> `08` fixture diff includes a whitespace-only change in `alic
 
 That should be treated as incidental fixture noise rather than intended semantic behavior for this task. The meaningful behavior in this slice is the Knop inventory update plus the new references catalog file.
 
-## Open Issues
+## Resolved Questions
 
-- What should the exact first local CLI surface be for this operation?
-- Should the first slice expose `referenceRole` as an input, or hard-code the carried fixture role to `Canonical`?
-- Should shared `core` identify the subject referent implicitly from the target Knop, or explicitly in the request shape even though the carried fixture only needs the Knop-owned case?
+- This slice should get a dedicated [[wd.spec.2026-04-04-knop-add-reference-behavior]] note before implementation. The behavior is externally visible, crosses `core`, `runtime`, CLI, and acceptance layers, and already has a manifest-backed fixture target.
+- The first local CLI surface should be `weave knop add-reference <designatorPath> --reference-target-designator-path <referenceTargetDesignatorPath> --reference-role <referenceRole>`. Keep `knop.addReference` as the machine-facing job kind and manifest `operationId`, but keep the human-facing CLI aligned with the existing `mesh create` and `knop create` subcommand pattern.
+- The first local request/result boundary should stay narrow. Shared `core` and `runtime` should accept the target `designatorPath`, one `referenceTargetDesignatorPath`, and one `referenceRole`, resolve IRIs from the existing `meshBase`, and report the created `referenceCatalogIri`, `referenceLinkIri`, and created or updated paths.
+- The first slice should derive `referenceLinkFor` from the targeted Knop's `designatorPath`, not take an explicit subject override.
+- `ReferenceRole` should be an input rather than being hard-coded in the first slice, but this carried local path should require it explicitly rather than silently defaulting to `Supplemental`. The settled `08` target is specifically `Canonical`, and the later Bob extraction path is the first natural carried `Supplemental` case.
 
 ## Decisions
 
 - Treat `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` as the next carried implementation slice.
-- Add a dedicated reference-behavior `wd.spec.*` note before implementation.
+- Add a dedicated [[wd.spec.2026-04-04-knop-add-reference-behavior]] note before implementation.
 - Keep the first implementation local or in-process over shared `core` and `runtime`.
 - Use the settled Alice Bio `08-alice-bio-referenced` manifest and fixture as the first acceptance target.
 - Scope the first slice to the existing `alice` Knop-owned case with one canonical `ReferenceLink` targeting `alice/bio`.
+- Make the first local CLI surface `weave knop add-reference <designatorPath> --reference-target-designator-path <referenceTargetDesignatorPath> --reference-role <referenceRole>`, while keeping `knop.addReference` as the machine-facing job kind and manifest `operationId`.
+- Keep the first local request shape narrow: target `designatorPath`, one `referenceTargetDesignatorPath`, and one `referenceRole`, with `meshBase` resolved from the existing workspace.
+- Keep `referenceLinkFor` implicit from the targeted Knop's referent rather than accepting a separate subject IRI input.
+- Require `referenceRole` explicitly in this first carried local slice rather than silently defaulting it.
 - Keep the semantic subject of the link as `<alice>` rather than drifting into Knop-about-Knop semantics.
 - Leave `09` weave behavior, catalog history, dereferenceable current catalog pages, and retired-link handling for the following woven slice.
 - Keep the broader RDF-parsing cleanup task separate unless this slice reveals a direct blocker.
 
 ## Contract Changes
 
-- This task may introduce the first thin public request/result examples for `knop.addReference` or equivalent reference-catalog creation behavior in `semantic-flow-framework`.
-- This task should not attempt to finalize the full contract for multi-link updates, role selection, `referenceTargetState`, or mesh-owned catalogs.
+- This task may introduce the first thin public request/result examples for `knop.addReference` in `semantic-flow-framework`, including one explicit `referenceRole`.
+- This task should not attempt to finalize the full contract for multi-link updates, role selection, explicit subject override, `referenceTargetState`, or mesh-owned catalogs.
 
 ## Testing
 
 - Follow [[wd.testing]].
-- Add failing unit tests for the next narrow planning logic where practical, especially stable link identity and inventory updates.
+- Add failing unit tests for the next narrow planning logic where practical, especially stable link identity, role handling, and inventory updates.
 - Add integration tests for local filesystem results against the settled `08-alice-bio-referenced` fixture target.
 - Add a black-box CLI acceptance test scoped by the settled `08-alice-bio-referenced` Accord manifest.
 - Keep the comparison black-box and fixture-oriented rather than coupling tests to helper internals.
@@ -124,11 +130,11 @@ That should be treated as incidental fixture noise rather than intended semantic
 
 ## Implementation Plan
 
-- [ ] Decide whether the first reference-catalog slice needs a dedicated `wd.spec.*` note before implementation.
-- [ ] Define the first local request/result shapes in shared `core` and `runtime` for adding a single Knop-owned reference.
-- [ ] Define the exact first local CLI surface for the carried reference-catalog operation.
-- [ ] Add failing unit and integration tests for the `08` reference-catalog behavior.
-- [ ] Implement the next local or in-process reference-catalog path over shared `core` and `runtime`.
-- [ ] Add a black-box CLI acceptance test scoped by the settled `08-alice-bio-referenced` Accord manifest.
-- [ ] Draft or refine the thin public API example or contract fragment in `semantic-flow-framework` if this slice sharpens the public contract.
-- [ ] Update relevant overview/spec/framework notes as the slice settles.
+- [x] Decide whether the first reference-catalog slice needs a dedicated `wd.spec.*` note before implementation.
+- [x] Define the first local request/result shapes in shared `core` and `runtime` for adding a single Knop-owned reference.
+- [x] Define the exact first local CLI surface for the carried reference-catalog operation.
+- [x] Add failing unit and integration tests for the `08` reference-catalog behavior.
+- [x] Implement the next local or in-process reference-catalog path over shared `core` and `runtime`.
+- [x] Add a black-box CLI acceptance test scoped by the settled `08-alice-bio-referenced` Accord manifest.
+- [c] Draft or refine the thin public API example or contract fragment in `semantic-flow-framework` if this slice sharpens the public contract.
+- [x] Update relevant overview/spec/framework notes as the slice settles.

--- a/documentation/notes/wd.conv.2026.2026-04-04_1524-weave-alice-bio-integrated-woven-codex.md
+++ b/documentation/notes/wd.conv.2026.2026-04-04_1524-weave-alice-bio-integrated-woven-codex.md
@@ -141,6 +141,6 @@ The next task note is in place and `wd.todo` now points at it plus the separate 
 
 Yes.
 
-I created the next carried-slice note at [[wd.task.2026.2026-04-04-alice-bio-referenced]] and added it to [[wd.todo]]. I scoped it to the settled `07-alice-bio-integrated-woven -> 08-alice-bio-referenced` transition: first `alice` `ReferenceCatalog`, one canonical `ReferenceLink` about `<alice>` targeting `<alice/bio>`, with no weave/history/page-generation behavior yet.
+I created the next carried-slice note at [[wd.completed.2026.2026-04-04-alice-bio-referenced]] and added it to [[wd.todo]]. I scoped it to the settled `07-alice-bio-integrated-woven -> 08-alice-bio-referenced` transition: first `alice` `ReferenceCatalog`, one canonical `ReferenceLink` about `<alice>` targeting `<alice/bio>`, with no weave/history/page-generation behavior yet.
 
 I also pushed back on one point in the note: `RDF parsing` is still a valid task, but it should stay a separate cleanup track, not replace the next carried semantic slice. The next concrete move after this note is to write the dedicated reference-behavior spec that the task calls for.

--- a/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
+++ b/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
@@ -344,3 +344,206 @@ fix(knop): harden add-reference validation and atomic writes
 - treat success logging as best-effort after commit
 - add regression tests for invalid inputs and logging-failure behavior
 ```
+
+# User_2026-04-04_2019_36
+
+can you compose a task for the next slice?
+
+# gpt-5.4_2026-04-04_2019_46
+
+I’m checking the current `09` task note and the conformance sequence so the next slice note lands on the right transition and uses the same task-note structure.
+
+# gpt-5.4_2026-04-04_2019_55
+
+I’ve confirmed the current task is the `08 -> 09` weave slice, so the next real step is the `09 -> 10` semantic update. I’m reading the settled `10` manifest and nearby completed task patterns so the new note is scoped tightly instead of turning into a vague “update something” placeholder.
+
+# gpt-5.4_2026-04-04_2020_04
+
+I have the next timestamp. I’m checking the actual `09 -> 10` fixture delta so the task note names the real semantic surface: which files should change, which ones must stay frozen, and whether this wants a new dedicated `payload.update` spec note or just a thin extension of the existing integrate/update guidance.
+
+# gpt-5.4_2026-04-04_2020_27
+
+The fixture delta is clean: `09 -> 10` changes only `alice-bio.ttl`, and the manifest names the operation `payload.update`. I’m drafting the task as a deliberately narrow non-woven semantic slice, not a general RDF-editing project and not the later `v2` weave.
+
+# gpt-5.4_2026-04-04_2020_53
+
+There isn’t an existing `payload.update` behavior spec, unlike `mesh.create`, `knop.create`, `integrate`, `knop.addReference`, and `weave`. I’m treating that as part of the task: queue the new semantic slice and make the task explicitly say a dedicated narrow `payload.update` spec should be written rather than smuggling the behavior into the weave note.
+
+# gpt-5.4_2026-04-04_2021_00
+
+I have enough to draft it. The new task is going to be a narrow `payload.update` slice: one working payload file changes, every woven artifact stays frozen, and the later `11` weave remains explicitly out of scope.
+
+# gpt-5.4_2026-04-04_2021_04
+
+I’m writing the note now and queueing it in `wd.todo`. I’m also keeping the internal links in Dendron style and leaving the currently active `09` task untouched, since this is just the follow-on slice.
+
+# gpt-5.4_2026-04-04_2022_14
+
+The note is in place and queued. I’m giving it one quick pass for wording and linkage so the next person picking it up doesn’t get tripped by an accidental ambiguity in the scope or spec reference.
+
+# gpt-5.4_2026-04-04_2022_18
+
+Drafted the next slice task at [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]]. It queues the narrow `09-alice-bio-referenced-woven` -> `10-alice-bio-updated` `payload.update` slice, with the core constraint that only `alice-bio.ttl` changes and all woven support artifacts stay frozen.
+
+I also added it to [[wd.todo#L10]], immediately after the current `09` weave task. No tests run; this was a docs-only update.
+
+# User_2026-04-04_2023_30
+
+update the implementation plan in [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]]
+
+# gpt-5.4_2026-04-04_2023_42
+
+I’m checking the current task note against the live code and tests so the implementation plan reflects what is already settled versus what still belongs to the `09` slice.
+
+# gpt-5.4_2026-04-04_2023_54
+
+The current plan still reads like an unsifted draft even though the note already settles a few of those questions in prose. I’m checking the prior task-note pattern so I can update this one consistently instead of just flipping boxes at random.
+
+# gpt-5.4_2026-04-04_2024_19
+
+I found the mismatch: the note already settles the spec and request-shape questions in prose, but the plan still treats them as open work. I’m tightening the plan so it shows those items as resolved and breaks the remaining `09` work into the concrete artifact/history, inventory, page, and acceptance steps that are actually left.
+
+# gpt-5.4_2026-04-04_2024_30
+
+The plan is updated. I’m doing a quick readback so I don’t leave the note with a plan that contradicts the earlier decisions section.
+
+# gpt-5.4_2026-04-04_2024_35
+
+Updated the implementation plan in [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven#L131]].
+
+The main change was to align the plan with what the note already settles:
+- marked the spec-sufficiency and narrow-request-shape items complete
+- removed the speculative framework-contract item
+- split the remaining work into the actual `09` slice deliverables: tests, page-seam extension, `alice/_knop/_references` first-history weaving, `alice/_knop/_inventory` advancement with `_mesh/_inventory` unchanged, and the black-box acceptance test
+
+No tests run; this was a docs-only edit.
+
+# User_2026-04-04_2029_44
+
+fix the lint errors
+
+# gpt-5.4_2026-04-04_2029_51
+
+I’m running the repo lint task first to get the actual failures from the current tree, then I’ll patch only the files that are still violating lint.
+
+# gpt-5.4_2026-04-04_2029_56
+
+The failures are narrow and confined to the new regression test doubles. I’m checking the sink interface and then I’ll make the smallest change that satisfies lint without changing test behavior.
+
+# gpt-5.4_2026-04-04_2029_57
+
+I’ve got the cause: those sink stubs are allowed to be synchronous by the `LogSink` interface, so the `async` keywords are unnecessary. I’m removing them and rerunning lint.
+
+# gpt-5.4_2026-04-04_2030_08
+
+Fixed the lint errors in [knop_add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/knop_add_reference_test.ts#L151) by removing unnecessary `async` from the synchronous test sink stubs.
+
+Verification: `deno task lint` now passes. I did not run the full test suite.
+
+# User_2026-04-04_2153_30
+
+What about : 
+
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@src/runtime/knop/add_reference.ts`:
+- Around line 121-148: The catch block currently awaits operationalLogger.error
+and auditLogger.record and can throw, masking the original
+KnopAddReference*Error; change it to preserve the original error (capture it as
+originalErr), compute the message, then call operationalLogger.error and
+auditLogger.record inside their own try/catch blocks (best-effort: swallow/log
+any logging failures but do not let them throw), and finally rethrow the
+originalErr so the original validation/commit failure is propagated; reference
+operationalLogger.error, auditLogger.record and the surrounding catch for the
+addReference flow.
+
+In `@tests/integration/knop_add_reference_test.ts`:
+- Around line 151-169: The test sinks' async write(record) stubs in the
+StructuredLogger used for throwingOperationalLogger and the inner
+StructuredLogger passed to AuditLogger must explicitly return a Promise to
+satisfy require-await; modify both write implementations (the write methods on
+the StructuredLogger instances) to return Promise.reject(new Error("operational
+success log failed")) / Promise.reject(new Error("audit success log failed"))
+when record.event === "knop.addReference.succeeded" and return Promise.resolve()
+otherwise so the failure injection still works but lint passes.
+
+---
+
+Duplicate comments:
+In `@src/runtime/knop/add_reference.ts`:
+- Around line 501-504: The two-step swap in the loop
+(Deno.rename(file.absolutePath, file.backupPath!) followed by
+Deno.rename(file.tempPath, file.absolutePath)) is non-atomic because the
+destination can be missing between awaits; change this to an atomic replace by
+renaming the new file directly over the destination (use
+Deno.rename(file.tempPath, file.absolutePath)) so the target path is never
+missing. If you still need a backup, create it first with a non-destructive copy
+(e.g., Deno.copyFile(file.absolutePath, file.backupPath!)) and then atomically
+replace with Deno.rename(file.tempPath, file.absolutePath); update the loop in
+add_reference.ts to use these operations on the
+file.tempPath/file.absolutePath/file.backupPath symbols.
+
+# gpt-5.4_2026-04-04_2159_13
+
+I’m checking the live `knop add-reference` runtime and the current test double shape before touching anything. The failure-path logging and the updated-file commit loop are the two places that might still be real; the test-sink comment may already be stale after the lint fix.
+
+# gpt-5.4_2026-04-04_2159_35
+
+The live code confirms two of those review comments are still real: failure-path logging can mask the original error, and the updated-file commit path still moves the destination out of the way before replacement. The test-sink comment is stale now that those stubs are synchronous and `deno task lint` already passes.
+
+# gpt-5.4_2026-04-04_2159_47
+
+I’m patching both real issues now: failure logging becomes best-effort so it can’t mask the underlying error, and the updated-file commit loop will stop moving the live destination out of the way before replacement. I’m also adding one regression test for the failure-path logging case so this doesn’t reopen later.
+
+# gpt-5.4_2026-04-04_2200_12
+
+I’m patching the runtime in two spots now: the `catch` path will log best-effort and rethrow the original normalized failure, and the updated-file commit path will switch from rename-away-then-rename-in to backup-copy plus direct replacement. After that I’ll add a regression test for the failure-logging case.
+
+# gpt-5.4_2026-04-04_2200_26
+
+The runtime changes are in. I’m adding the regression test that forces the failure logger path to throw, so we prove the underlying add-reference error still surfaces instead of getting replaced by a logging error.
+
+# gpt-5.4_2026-04-04_2200_43
+
+I’ve added the regression coverage. Next I’m formatting the touched files and running the targeted `knop add-reference` tests plus lint so we can separate real behavior issues from simple formatting noise.
+
+# gpt-5.4_2026-04-04_2200_46
+
+Lint is clean. The targeted tests are compiling now; I’m waiting for the actual runtime results, especially the new failure-logging regression, before I touch anything else.
+
+# gpt-5.4_2026-04-04_2200_50
+
+The targeted `knop add-reference` suite is green. I’m running the normal repo test task once more because the runtime commit path changed, and that’s the quickest way to rule out spillover beyond the focused regression set.
+
+# gpt-5.4_2026-04-04_2201_12
+
+I verified all three review items against the current tree and the tests are green. I’m pulling exact line references now so the close-out can distinguish the two real fixes from the one stale comment I intentionally left alone.
+
+# gpt-5.4_2026-04-04_2201_29
+
+Two of those findings were still real, and I fixed them.
+
+- Failure-path logging masking the original error: real. The `catch` in [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/knop/add_reference.ts#L121) now normalizes the original failure first, logs with best-effort helpers in [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/knop/add_reference.ts#L582), and rethrows the original normalized add-reference error instead of letting `operationalLogger.error` or `auditLogger.record` replace it.
+- Updated-file commit leaving the destination missing between awaits: real. The updated-file commit loop in [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/knop/add_reference.ts#L486) now copies the old file to backup and then renames the staged file directly onto the destination, instead of renaming the live destination away first.
+- Promise-returning test sink comment: stale. The current sink stubs in [knop_add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/knop_add_reference_test.ts#L158) and [knop_add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/knop_add_reference_test.ts#L205) are synchronous now, which already satisfies the `LogSink` interface and the lint rule, so I did not change them to explicit `Promise.resolve()` / `Promise.reject()` forms.
+
+I added a regression test for the failure-logging case in [knop_add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/knop_add_reference_test.ts#L142). Verification: `deno task lint` and `deno task test` both pass.
+
+# User_2026-04-04_2209_36
+
+commit mesg.
+
+What next?
+
+# gpt-5.4_2026-04-04_2209_55
+
+```text
+fix(knop): preserve add-reference failures and tighten staged replace
+
+- preserve the original add-reference error when failed-path logging throws
+- use backup copy plus direct staged rename for updated-file commits
+- add regression coverage for failed-path logging
+```
+
+Next should still be [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]], not [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]]. `09` is the next carried fixture slice and it unblocks `10`. I’d start that task by adding the failing `09-alice-bio-referenced-woven` integration and black-box CLI acceptance tests, then extend the shared weave/page seam for `ReferenceCatalog` pages.

--- a/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
+++ b/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
@@ -1,0 +1,171 @@
+---
+id: 08-weave-alice-bio-refer-f6sdcv
+title: '08 weave alice bio referenced'
+desc: ''
+created: 1775342261732
+updated: 1775342261732
+participants: [djradon, codex.gpt-5.4]
+---
+
+# User_2026-04-04_1530_10
+
+08 weave alice bio referenced
+
+Review [[AGENTS]] and [[dev.general-guidance]] and [[dev.testing]] and then let's settle the open issues.
+
+# gpt-5.4_2026-04-04_1530_23
+
+I’m pulling the repo guidance and the task note first so I can ground the discussion in the project’s actual constraints before touching the open issues.
+
+I’ve got the repo-level constraints. Next I’m checking the existing notes and code surface around reference links so the decisions land on what the project already does, not a speculative API.
+
+The next decision point is the API shape. I’m reading the existing spec language and CLI patterns so I can resolve the three open questions with a concrete recommendation instead of just replacing them with guesses.
+
+The docs already narrow two things: CLI actions are grouped as `mesh create`, `knop create`, and `integrate`, and stable reference-link fragment IDs are explicit. I’m reading the ontology notes now to settle the remaining request-shape question cleanly.
+
+The ontology note closes the subject question pretty hard: `referenceLinkFor` points to the actual subject resource, not the `Knop`. I’m checking the current `core` and `runtime` layout now so the CLI recommendation matches how the repo is actually structured.
+
+The code layout reinforces one choice already: the user-facing CLI is space-delimited subcommands, while dotted names are just audit/event IDs. I’m checking the existing tests and fixture harness now so the note update lines up with current acceptance patterns.
+
+I’ve got enough context to make the calls. Before editing, I’m checking the worktree so I don’t trample any unrelated user changes in the same note or neighboring docs.
+
+There’s already a draft API shape for `knop.addReference` in the framework repo. I’m reading that before I lock the note, because if the task note fights the draft contract now we’ll just be creating avoidable cleanup.
+
+The task note is clear enough to edit directly, but the repo’s own testing guidance says to write/refine a `wd.spec.*` note when behavior is still unclear. I’m reading the existing integrate spec so I can either mirror that pattern cleanly or avoid inventing a new style.
+
+I’m updating the task note now to replace the unresolved questions with explicit decisions, and I’m adding the dedicated behavior spec the repo guidance calls for so the implementation slice is actually pinned down before code work starts.
+
+The ambiguity is replaced with concrete decisions now. I’m reading both notes back once to catch any stale wording or mismatched scope before I hand this off.
+
+One wording point was sloppy: the `Knop` owns the catalog, while the referent is the subject of the link. I’m tightening that now so the spec doesn’t encode the wrong relationship.
+
+Settled the open issues in [[wd.completed.2026.2026-04-04-alice-bio-referenced]] and added the dedicated behavior spec at [[wd.spec.2026-04-04-knop-add-reference-behavior]].
+
+The decisions are now explicit:
+- first local CLI: `weave knop add-reference <designatorPath> --reference-target-designator-path <referenceTargetDesignatorPath>`
+- machine-facing job kind / manifest `operationId` stays `knop.addReference`
+- first slice hard-codes `ReferenceRole/Canonical`
+- `referenceLinkFor` is implicit from the targeted Knop’s referent, not a separate input
+- local request/result stays narrow: `designatorPath` + `referenceTargetDesignatorPath`, with result reporting `referenceCatalogIri`, `referenceLinkIri`, and changed paths
+
+I also marked the first three implementation-plan items as resolved. No tests run; this was a documentation-only change.
+
+# User_2026-04-04_1537_20
+
+I think we should take ReferenceRole as input. If not specified, I'd say it would default to Supplemental.
+
+# gpt-5.4_2026-04-04_1537_40
+
+I’m checking the ontology and the carried `08` fixture before changing the decision, because this is exactly the kind of place where a “reasonable default” can quietly diverge from the settled scenario.
+
+# gpt-5.4_2026-04-04_1538_15
+
+I checked the ontology and the carried manifest. The important conflict is that the settled `08` acceptance target is explicitly `Canonical`, not just “some reference role,” so a silent default to `Supplemental` would only be safe if the caller always overrides it for this first slice.
+
+# gpt-5.4_2026-04-04_1538_44
+
+I’m revising the note and the spec to take `ReferenceRole` as an input, but I’m not going to encode a silent `Supplemental` default into this first carried slice. That default is broader policy, and the first covered omission case does not exist yet.
+
+# gpt-5.4_2026-04-04_1539_11
+
+The compromise is in place: role is now an input, but the first local slice requires it explicitly instead of silently inventing semantics on omission. I’m reading the diffs once to make sure the note and spec still agree with each other.
+
+# gpt-5.4_2026-04-04_1539_20
+
+I’ve got the docs consistent. I’m grabbing exact line references now so the reasoning and the edited decisions point at the concrete sources, not just my summary.
+
+# gpt-5.4_2026-04-04_1539_31
+
+Updated the docs to take `referenceRole` as input on the first local surface: [[wd.completed.2026.2026-04-04-alice-bio-referenced#L85]] and [[wd.spec.2026-04-04-knop-add-reference-behavior#L21]] now use `weave knop add-reference <designatorPath> --reference-target-designator-path <referenceTargetDesignatorPath> --reference-role <referenceRole>` and treat `referenceRole` as part of the narrow local request shape.
+
+I did not adopt a silent `Supplemental` default. The settled `08` acceptance target explicitly asserts `ReferenceRole/Canonical` for this first carried slice in [08-alice-bio-referenced.jsonld](/home/djradon/hub/semantic-flow/weave/dependencies/github.com/semantic-flow/semantic-flow-framework/examples/alice-bio/conformance/08-alice-bio-referenced.jsonld#L29) and [08-alice-bio-referenced.jsonld](/home/djradon/hub/semantic-flow/weave/dependencies/github.com/semantic-flow/semantic-flow-framework/examples/alice-bio/conformance/08-alice-bio-referenced.jsonld#L161), while the ontology defines the role vocabulary but no default in [semantic-flow-core-ontology.ttl](/home/djradon/hub/semantic-flow/weave/dependencies/github.com/semantic-flow/ontology/semantic-flow-core-ontology.ttl#L210). So the docs now require the role explicitly for this first local slice instead of inventing omission semantics. If you want a global `Supplemental` default later, that should get its own spec and fixture.
+
+No tests run.
+
+# User_2026-04-04_1541_06
+
+OK proceed. I guess spec is next?
+
+# gpt-5.4_2026-04-04_1541_21
+
+The spec note is already in place at [[wd.spec.2026-04-04-knop-add-reference-behavior]]. I’m moving to the next real step now: failing tests and the first local `knop add-reference` implementation against the settled `08` fixture.
+
+# gpt-5.4_2026-04-04_1541_54
+
+I’ve got the fixture shape and test patterns. Next I’m wiring the new `core`/`runtime`/CLI slice and adding the matching unit, integration, and e2e tests against `07 -> 08`.
+
+# gpt-5.4_2026-04-04_1544_11
+
+I’m editing the implementation now. The main risk is path and Turtle mutation, so I’m keeping the new slice isolated in `knop/add_reference` and deriving the tests directly from the settled `07 -> 08` fixture.
+
+# gpt-5.4_2026-04-04_1546_21
+
+The slice is wired end-to-end now. I’m doing the cleanup pass next: formatting, compile fixes, and then the targeted test run to see what the fixture comparisons disagree with.
+
+# gpt-5.4_2026-04-04_1546_34
+
+The code is through typechecking and into the test run. I’m polling the failures now; the likely friction is exact Turtle insertion order or the CLI wiring.
+
+# gpt-5.4_2026-04-04_1546_47
+
+The first test pass exposed exactly the two expected friction points: one CLI parsing bug and one inventory insertion-order mismatch against the settled `08` file. I’m fixing those now rather than broadening the scope.
+
+# gpt-5.4_2026-04-04_1547_17
+
+The second pass is through typechecking again. I’m checking whether the remaining failures are semantic or just exact fixture formatting.
+
+# gpt-5.4_2026-04-04_1547_23
+
+The new slice passes its own unit, integration, and e2e acceptance tests. I’m running the repo test task now to make sure the new command didn’t break adjacent slices.
+
+# gpt-5.4_2026-04-04_1547_50
+
+The feature is implemented and the full repo test task is green. I’m doing one last repo-hygiene pass now: task-note status and any lightweight documentation updates that the completed slice made concrete.
+
+# gpt-5.4_2026-04-04_1548_01
+
+The code is done. I’m closing the loop on the task note now so the implementation status matches reality, and I’m checking whether there’s a minimal decision-log or overview update worth making instead of leaving the docs behind.
+
+# gpt-5.4_2026-04-04_1548_13
+
+The implementation is green. I’m making the note trail match that reality now: closing the task checklist, adding the decision-log entry, and updating the overview so the next slice doesn’t start from stale repo docs.
+
+# gpt-5.4_2026-04-04_1548_37
+
+I’m renaming the task note to `wd.completed.*` and fixing the live links with it. That keeps `wd.todo`, the decision log, and the overview aligned with the implemented slice instead of leaving a finished task open.
+
+# gpt-5.4_2026-04-04_1549_24
+
+The note trail is now closed forward, but I’m doing one quick link sweep to catch any stale `wd.task...alice-bio-referenced` references left behind by the rename.
+
+# gpt-5.4_2026-04-04_1549_55
+
+Implemented the first local `knop add-reference` slice end-to-end. The new CLI surface is wired in [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts#L175), core planning and Turtle mutation live in [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/core/knop/add_reference.ts#L16), and local execution/logging live in [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/knop/add_reference.ts#L13). It now creates `alice/_knop/_references/references.ttl`, updates the existing Knop inventory to register the `ReferenceCatalog`, derives `referenceLinkFor` from the target designator, and requires an explicit `referenceRole` token that maps to the ontology IRI.
+
+I added unit, integration, and black-box CLI coverage in [add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/knop/add_reference_test.ts), [knop_add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/knop_add_reference_test.ts#L13), and [knop_add_reference_cli_test.ts](/home/djradon/hub/semantic-flow/weave/tests/e2e/knop_add_reference_cli_test.ts#L18). I also closed the note trail: the task note is now [[wd.completed.2026.2026-04-04-alice-bio-referenced]], with matching updates to [[wd.spec.2026-04-04-knop-add-reference-behavior]], [[wd.decision-log]], [[wd.codebase-overview]], and [[wd.todo]]. I did not change `semantic-flow-framework`; the existing draft `knop.addReference` surface was enough for this local slice.
+
+Verification: `deno task test`
+
+# User_2026-04-04_1550_20
+
+commit message please
+
+# gpt-5.4_2026-04-04_1550_28
+
+I’m checking the current diff summary so the commit message matches the actual change set, including the task-note rename and doc updates.
+
+# gpt-5.4_2026-04-04_1550_31
+
+The tracked diff omits the new files, so I’m pulling the worktree status too before I draft the message.
+
+# gpt-5.4_2026-04-04_1550_42
+
+```text
+feat(knop): implement first local add-reference slice
+
+- add core planning and local runtime execution for `knop.addReference`
+- wire `weave knop add-reference` into the CLI with explicit target designator and `referenceRole`
+- add unit, integration, and black-box CLI tests for the settled `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` fixture
+- add `[[wd.spec.2026-04-04-knop-add-reference-behavior]]` for the first carried reference-catalog behavior
+- rename the task note to completed and update `wd.todo`, `wd.decision-log`, `wd.codebase-overview`, and related conversation links
+```

--- a/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
+++ b/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
@@ -205,3 +205,142 @@ Added the “leave task-note renames to the user unless explicitly asked” rule
 Drafted the next carried-slice task note at [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]] and queued it in [[wd.todo]]. It scopes the next slice to `08-alice-bio-referenced -> 09-alice-bio-referenced-woven`: weave `alice/_knop/_references`, advance `alice/_knop/_inventory`, generate the catalog pages, and leave `_mesh/_inventory` unchanged.
 
 No tests run; this was a docs-only update.
+
+# User_2026-04-04_1634_40
+
+coderabbit feedback:
+
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@src/cli/run.ts`:
+- Around line 198-227: Trim and validate the positional designatorPath inside
+the .action handler before using it: call designatorPath =
+String(designatorPath).trim() (or equivalent) after it is received, then check
+it is non-empty and if invalid throw/return a clear error (same pattern as
+resolveRequiredOptionValue) so execution (including executeKnopAddReference and
+auditLogger.command) never proceeds with a whitespace-only value; update any
+error message to mention the positional designatorPath.
+
+In `@src/core/knop/add_reference.ts`:
+- Around line 50-68: normalizeDesignatorPath currently allows segments like
+"alice:bio" that can produce non-mesh-relative IRIs; update
+normalizeDesignatorPath to validate each segment against a safe segment charset
+(only allow a-z, A-Z, 0-9, hyphen, underscore, dot — reject colons, slashes,
+spaces, etc.), and throw a clear validation error when a segment fails. In
+add_reference.ts (places constructing designatorPath and
+referenceTargetDesignatorPath and where toKnopPath is used) call the tightened
+normalizeDesignatorPath and ensure any invalid input causes fast failure rather
+than producing IRIs; mirror the identical charset check in the runtime validator
+code paths mentioned (the blocks around lines 117-153 and 168-185) so both
+compile-time and runtime enforce the same rule. Ensure error messages reference
+the offending segment and the function names normalizeDesignatorPath and
+toKnopPath for easy debugging.
+- Around line 155-165: The normalizeReferenceRole function currently uses the
+"in" operator against referenceRoleIriByToken which matches prototype properties
+(e.g., "constructor"); change the validation to check only own properties by
+using Object.prototype.hasOwnProperty.call(referenceRoleIriByToken, normalized)
+instead of "normalized in referenceRoleIriByToken", keep throwing
+KnopAddReferenceInputError for empty/unsupported values and return the
+normalized value as ReferenceRoleToken as before.
+
+In `@src/runtime/knop/add_reference.ts`:
+- Around line 102-108: The workspace mutation is not atomic because
+writeCreatedFiles and writeUpdatedFiles commit changes before all work (and
+success logging) completes; modify the add-reference flow so mutations are done
+atomically: for created files use a staging-and-rename strategy (write to temp
+paths then atomically rename into final paths) or implement a rollback path that
+removes any newly created files if a later step fails, and ensure
+writeUpdatedFiles applies updates transactionally (e.g., write to temp files and
+replace). Keep the pre-checks (assertReferenceTargetExists,
+assertCreateTargetsDoNotExist) as-is but perform the staged commit immediately
+after those checks and before any post-commit logging; make the success log
+calls best-effort (catch/log but don’t throw) so logging failures do not leave
+the workspace mutated without allowing retries. Ensure the new behavior is
+applied to both the block around writeCreatedFiles/writeUpdatedFiles and the
+other occurrence noted (lines ~159-188) so all workspace mutations are atomic.
+
+# gpt-5.4_2026-04-04_1635_10
+
+I’m verifying the actual code paths against the review comments first, then I’ll patch only the findings that are real for the current `knop add-reference` slice.
+
+# gpt-5.4_2026-04-04_1635_57
+
+Verifying the CodeRabbit findings against the current implementation now. I’m checking each one in the live code, then I’ll patch only the issues that are real and add tests where the behavior changed.
+
+# gpt-5.4_2026-04-04_1636_06
+
+The three substantive findings are real in the current tree: positional CLI validation is missing, path-segment validation is too permissive, and the runtime write path is not atomic. I’m patching those now and I’ll add focused regression coverage for the new failure cases instead of changing unrelated behavior.
+
+# gpt-5.4_2026-04-04_1638_15
+
+I’ve narrowed the fix scope to the actual regressions in `knop add-reference`. I’m editing the CLI first so whitespace-only positional input is rejected before any audit logging or runtime execution.
+
+# gpt-5.4_2026-04-04_1638_21
+
+Next I’m tightening the designator-path normalization in the core planner. This is the place that was still willing to turn bad segments into IRIs, so I’m making the segment rule explicit and fixing the `referenceRole` own-property check at the same time.
+
+# gpt-5.4_2026-04-04_1639_06
+
+I’m on the runtime now. The change here is two parts: make the local validator match the planner’s segment rules, and stage the filesystem mutation so a later failure can roll back cleanly instead of leaving half-applied files behind.
+
+# gpt-5.4_2026-04-04_1639_44
+
+The core planner changes are in. I’m adding regression tests now for the two concrete input bugs that were real: bad path segments like `alice:bio` and prototype-property tokens like `constructor`.
+
+# gpt-5.4_2026-04-04_1640_17
+
+I’ve covered the planner and runtime. I’m adding one black-box CLI regression now so the whitespace-only positional case stays closed all the way out at the command surface.
+
+# gpt-5.4_2026-04-04_1640_39
+
+There’s one follow-up in the runtime patch: I’m making the post-commit cleanup actually best-effort so a temp-file cleanup miss can’t reintroduce the same “mutation succeeded but the command failed” class of problem.
+
+# gpt-5.4_2026-04-04_1641_06
+
+The fixes are patched. I’m formatting the touched files and then running the targeted `knop add-reference` tests first so I can catch any type or behavior regressions before deciding whether a full suite run is worth the extra time.
+
+# gpt-5.4_2026-04-04_1641_10
+
+The test compile step is past formatting and into execution. If anything fails now it should be a real behavioral mismatch, not just syntax or lint noise.
+
+# gpt-5.4_2026-04-04_1641_16
+
+The failures are permission-related, not code failures. I’m rerunning the same targeted tests with the permissions those integration and CLI cases actually need so we can see the real result set.
+
+# gpt-5.4_2026-04-04_1641_27
+
+The targeted regressions are green. I’m running the repo’s normal test task once to make sure the tighter validation and CLI surface didn’t break anything outside the `add-reference` slice.
+
+# gpt-5.4_2026-04-04_1641_50
+
+The code changes are done and the full repo test task passed. I’m just collecting the exact file/line references now so the close-out is precise and I can distinguish the actual fixes from unrelated workspace noise.
+
+# gpt-5.4_2026-04-04_1642_20
+
+I verified the CodeRabbit comments against the current code. The CLI positional validation issue, the unsafe designator-segment issue, the `referenceRole` own-property issue, and the non-atomic runtime write path were all real, so I fixed those and nothing broader.
+
+- In [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts#L198), `knop add-reference` now trims and validates the positional `designatorPath` before any audit logging or execution, with a clear error that names the positional argument.
+- In [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/core/knop/add_reference.ts#L122) and [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/core/knop/add_reference.ts#L170), `normalizeDesignatorPath` now rejects unsafe segments like `alice:bio` with an error that mentions `normalizeDesignatorPath` and `toKnopPath`, and `normalizeReferenceRole` now uses `hasOwnProperty` instead of `in`.
+- In [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/knop/add_reference.ts#L311), [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/knop/add_reference.ts#L359), and [add_reference.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/knop/add_reference.ts#L597), the runtime now enforces the same segment rule, stages file writes through temp files plus rollback, and treats success logging as best-effort so a committed mutation does not fail afterward.
+
+I added regression coverage in [add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/knop/add_reference_test.ts#L157), [knop_add_reference_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/knop_add_reference_test.ts#L112), and [knop_add_reference_cli_test.ts](/home/djradon/hub/semantic-flow/weave/tests/e2e/knop_add_reference_cli_test.ts#L103). Verification: `deno task test` passed.
+
+There is also an unrelated modified note in the worktree, [[wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex]], which I left alone.
+
+# User_2026-04-04_1958_25
+
+commit mesg?
+
+# gpt-5.4_2026-04-04_1958_51
+
+```text
+fix(knop): harden add-reference validation and atomic writes
+
+- validate and trim the positional `designatorPath` in the CLI
+- reject unsafe designator path segments in core and runtime normalization
+- use an own-property check for `referenceRole` token validation
+- stage add-reference workspace mutations atomically with rollback on failure
+- treat success logging as best-effort after commit
+- add regression tests for invalid inputs and logging-failure behavior
+```

--- a/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
+++ b/documentation/notes/wd.conv.2026.2026-04-04_1537-08-weave-alice-bio-referenced-codex.md
@@ -169,3 +169,39 @@ feat(knop): implement first local add-reference slice
 - add `[[wd.spec.2026-04-04-knop-add-reference-behavior]]` for the first carried reference-catalog behavior
 - rename the task note to completed and update `wd.todo`, `wd.decision-log`, `wd.codebase-overview`, and related conversation links
 ```
+
+# User_2026-04-04_1553_05
+
+In the future let me move the task files to completed. 
+
+Maybe add that to Agents.md
+
+Can you compose the next slice task item. Includ the time in the filename, like _1553
+
+# gpt-5.4_2026-04-04_1553_14
+
+I’m updating the repo guidance first so it doesn’t keep telling agents to rename task notes, then I’ll draft the next carried-slice note with the requested `_1553` timestamped filename.
+
+# gpt-5.4_2026-04-04_1553_36
+
+I’ve got the current queue. I’m reading the settled `09` fixture guidance and the last weave task pattern now so the new `_1553` task note is concrete instead of just “next is 09”.
+
+# gpt-5.4_2026-04-04_1553_48
+
+I’ve got the transition shape. I’m checking the actual `09` inventory and page outputs now so the note captures the real weave consequences, especially the “advance Knop inventory but not mesh inventory” boundary.
+
+# gpt-5.4_2026-04-04_1553_58
+
+I’m writing three doc changes now: the “don’t rename task notes unless asked” guidance, the new `_1553` weave task note for `08 -> 09`, and the todo update so the next slice is actually queued.
+
+# gpt-5.4_2026-04-04_1554_34
+
+The new task note and guidance updates are in place. I’m reading them back once to make sure the filename, wikilinks, and the “user handles renames” rule all landed cleanly.
+
+# gpt-5.4_2026-04-04_1554_41
+
+Added the “leave task-note renames to the user unless explicitly asked” rule to [[AGENTS]] and also to [[wd.general-guidance]] so the repo guidance doesn’t contradict itself.
+
+Drafted the next carried-slice task note at [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]] and queued it in [[wd.todo]]. It scopes the next slice to `08-alice-bio-referenced -> 09-alice-bio-referenced-woven`: weave `alice/_knop/_references`, advance `alice/_knop/_inventory`, generate the catalog pages, and leave `_mesh/_inventory` unchanged.
+
+No tests run; this was a docs-only update.

--- a/documentation/notes/wd.decision-log.md
+++ b/documentation/notes/wd.decision-log.md
@@ -159,3 +159,11 @@ created: 1773630801215
 - References: [[wd.completed.2026.2026-04-04-weave-alice-bio-integrated-woven]], [[wd.spec.2026-04-03-weave-behavior]]
 - Why:
   - Parse validation is enough to carry the settled `07` payload weave slice without pretending the broader validator stack is already implemented.
+
+### 2026-04-04: First Local knop.addReference Slice Targets Alice 07 -> 08
+
+- Decision: Treat the settled Alice Bio `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` transition as the first carried local `knop.addReference` slice, expose the human-facing CLI as `weave knop add-reference <designatorPath> --reference-target-designator-path <referenceTargetDesignatorPath> --reference-role <referenceRole>`, keep `knop.addReference` as the machine-facing job kind, derive `referenceLinkFor` from the targeted Knop's referent, and require `referenceRole` explicitly rather than silently defaulting it.
+- References: [[wd.completed.2026.2026-04-04-alice-bio-referenced]], [[wd.spec.2026-04-04-knop-add-reference-behavior]]
+- Why:
+  - The settled `08` fixture explicitly proves a canonical Alice -> Alice Bio link rather than an omission-default role policy.
+  - The later Bob extraction path is the first natural carried `Supplemental` case, so a silent local default would have blurred two different fixture-backed behaviors.

--- a/documentation/notes/wd.general-guidance.md
+++ b/documentation/notes/wd.general-guidance.md
@@ -48,7 +48,9 @@ see [[wd.testing]]
 
 Before starting substantial code changes, a task note should be written and refined. Task notes live in `documentation/notes/wd.task.*` and the template lives in [[template.task]]. Actionable "To-Do" items should be pre-pended with markdown checkboxes (`[ ]`) to track completion (`[x]`) or cancellation (`[c]`)
 
-When a task is materially complete and you want its status reflected in the note name, rename the note from `wd.task.*` to `wd.completed.*` rather than creating a separate duplicate summary note by default. If the rename changes wikilinks, update the affected references.
+When a task is materially complete and you want its status reflected in the note name, prefer renaming the note from `wd.task.*` to `wd.completed.*` rather than creating a separate duplicate summary note by default. If the rename changes wikilinks, update the affected references.
+
+If the user has indicated they prefer to perform that rename manually, do not rename the note unless they explicitly ask you to.
 
 Before a task is closed, [[wd.decision-log]] should be updated with important decisions made.
 

--- a/documentation/notes/wd.spec.2026-04-04-knop-add-reference-behavior.md
+++ b/documentation/notes/wd.spec.2026-04-04-knop-add-reference-behavior.md
@@ -1,0 +1,80 @@
+---
+id: n4p7r2k8m1x6c3v9t0b5wda
+title: 2026 04 04 Knop Add Reference Behavior
+desc: ''
+updated: 1775368800000
+created: 1775368800000
+---
+
+## Purpose
+
+This note captures the current expected behavior of the first `knop add-reference` slice for Weave.
+
+It is an implementation-facing behavior spec for the first local or in-process path, not a final public API contract.
+
+## Status
+
+This is the current next carried slice after the first completed local payload-oriented `weave` implementation.
+
+The first acceptance target is the settled `mesh-alice-bio` transition from `07-alice-bio-integrated-woven` to `08-alice-bio-referenced`.
+
+## Inputs
+
+- the machine-facing job kind and manifest `operationId` stay `knop.addReference`
+- the first local CLI surface should be `weave knop add-reference <designatorPath> --reference-target-designator-path <referenceTargetDesignatorPath> --reference-role <referenceRole>`
+- `designatorPath` is required and identifies the target Knop that owns the `ReferenceCatalog`, while that Knop's referent is the subject of the `ReferenceLink`
+- `referenceTargetDesignatorPath` is required in the first slice and is resolved against the existing `meshBase` to form `referenceTarget`
+- `referenceRole` is required in this first carried local slice and should map to one ontology `ReferenceRole` IRI for the created link
+- the target workspace must already contain `_mesh/_meta/meta.ttl`, `_mesh/_inventory/inventory.ttl`, and the target Knop support surface
+- the carried `08` slice assumes the referenced target designator already exists as a mesh resource; this first slice does not auto-create referenced-resource Knops
+- `meshBase` is resolved from the existing mesh metadata rather than being repeated on the CLI
+- shared `core` and `runtime` should use a narrow local request shape: target `designatorPath`, `referenceTargetDesignatorPath`, and `referenceRole`, with result reporting the created `referenceCatalogIri`, `referenceLinkIri`, and created or updated paths
+- shared `core` planning should derive `referenceLinkFor` implicitly from the targeted Knop's `designatorPath` rather than accepting a separate subject IRI input
+- the settled `08` acceptance target uses `ReferenceRole/Canonical`; the later Bob extraction path is the first natural carried `ReferenceRole/Supplemental` case
+- this first local slice should not silently default an omitted role to `Supplemental`; omission is a broader policy question and is not covered by the current carried fixture
+
+## What Knop Add Reference Does
+
+`knop add-reference` establishes the first Knop-owned `ReferenceCatalog` surface for a designator in an existing mesh.
+
+In the current first slice, that means:
+
+- updating `D/_knop/_inventory/inventory.ttl` so the target Knop has `hasReferenceCatalog <D/_knop/_references>`
+- creating `D/_knop/_references/references.ttl`
+- registering `<D/_knop/_references>` as a `ReferenceCatalog`, `DigitalArtifact`, and `RdfDocument` with `hasWorkingLocatedFile <D/_knop/_references/references.ttl>`
+- creating one stable `ReferenceLink` rooted at `<D/_knop/_references#reference001>`
+- recording that link as about `<D>` with `referenceLinkFor <D>`, `hasReferenceRole <R>`, and `referenceTarget <T>`
+
+## What Knop Add Reference Does Not Do
+
+In this first slice, `knop add-reference` does not:
+
+- accept an explicit `referenceLinkFor` or subject-IRI override
+- accept multiple roles in one request
+- silently default an omitted local `referenceRole` to `Supplemental`
+- create more than one `ReferenceLink`
+- set `referenceTargetState`
+- auto-create a Knop for the referenced target
+- create explicit history or generated pages for `D/_knop/_references`
+- run `weave`, `version`, `validate`, or `generate`
+- introduce daemon behavior
+
+## Invariants
+
+- the `ReferenceLink` identity should be a stable fragment IRI rooted at the catalog resource, not a snapshot-local fragment
+- `referenceLinkFor` points to the actual subject resource `D`, not to `D/_knop`
+- the carried `08` Alice Bio acceptance path should produce `hasReferenceRole <.../ReferenceRole/Canonical>`
+- the carried Alice Bio path should leave `_mesh/_inventory/inventory.ttl`, `alice-bio.ttl`, `alice/_knop/_meta/meta.ttl`, and `alice/bio/_knop/_inventory/inventory.ttl` unchanged
+- the created and updated files should match the current intended `08-alice-bio-referenced` fixture state for Alice Bio
+- if the target reference-catalog working file already exists, the operation should fail closed rather than silently overwrite it
+- runtime-local `.weave/logs` output is not part of the semantic mesh surface
+
+## Acceptance Reference
+
+The first behavior-level comparison target is:
+
+- fixture repo: `dependencies/github.com/semantic-flow/mesh-alice-bio`
+- from ref: `07-alice-bio-integrated-woven`
+- to ref: `08-alice-bio-referenced`
+- manifest: `dependencies/github.com/semantic-flow/semantic-flow-framework/examples/alice-bio/conformance/08-alice-bio-referenced.jsonld`
+- local CLI execution should match that manifest-scoped result

--- a/documentation/notes/wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven.md
+++ b/documentation/notes/wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven.md
@@ -130,11 +130,11 @@ That means the task should prove the first history-aware catalog page shape with
 
 ## Implementation Plan
 
-- [ ] Confirm whether the existing weave behavior spec is sufficient as-is for the `09` slice.
-- [ ] Define the next local request/result shapes for `weave` in shared `core` and `runtime` if reference-catalog weaving requires a refinement.
+- [x] Confirm that [[wd.spec.2026-04-03-weave-behavior]] is sufficient as the current behavior spec for the `09` slice.
+- [x] Confirm that the existing thin local `weave` request/result shape stays narrow for this slice and does not require a new artifact-target model.
 - [ ] Add failing unit and integration tests for the `09` reference-catalog-weave behavior.
-- [ ] Define the minimal shared runtime page-model and HTML-rendering extension needed for current and historical `ReferenceCatalog` pages.
-- [ ] Implement the next local or in-process `weave` path over shared `core` and `runtime`.
+- [ ] Extend the existing shared runtime page-rendering seam to cover current and historical `ReferenceCatalog` pages without introducing a separate renderer path.
+- [ ] Implement the first-history `alice/_knop/_references` weave path and keep the working `references.ttl` file byte-identical to the latest historical snapshot after weave.
+- [ ] Implement `alice/_knop/_inventory` advancement to `_s0002` while keeping `_mesh/_inventory/inventory.ttl` unchanged.
 - [ ] Add a black-box CLI acceptance test scoped by the settled `09-alice-bio-referenced-woven` Accord manifest.
-- [ ] Draft or refine the thin public API example or contract fragment for `weave` in `semantic-flow-framework` if this slice sharpens the public contract.
 - [ ] Update relevant overview/spec/framework notes as the slice settles.

--- a/documentation/notes/wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven.md
+++ b/documentation/notes/wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven.md
@@ -1,0 +1,140 @@
+---
+id: z7k3v1m8p4x9q2n5c6t0wda
+title: 2026 04 04 1553 Weave Alice Bio Referenced Woven
+desc: ''
+updated: 1775368800000
+created: 1775371980000
+---
+
+## Goals
+
+- Carry the next real local `weave` slice after the first completed local `knop.addReference` implementation.
+- Implement the next local or in-process `weave` path over shared `core` and `runtime`.
+- Reuse the same spec, test, and acceptance pattern already used for the earlier carried slices.
+- Keep this `weave` implementation narrow enough to prove reference-catalog weaving behavior without absorbing Bob extraction or later richer retired-link handling.
+
+## Summary
+
+This task should pick up after the completed local `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` `knop.addReference` slice.
+
+The next carried slice should be the first local reference-catalog-oriented `weave` implementation, targeting the settled Alice Bio transition from `08-alice-bio-referenced` to `09-alice-bio-referenced-woven`.
+
+The target behavior is deliberately narrow:
+
+- version the new `alice/_knop/_references` artifact into its first explicit history
+- advance `alice/_knop/_inventory` from `_s0001` to `_s0002`
+- generate `alice/_knop/_references/index.html`
+- generate the first `alice/_knop/_references/_history001/...` ResourcePages
+- keep `_mesh/_inventory/inventory.ttl` unchanged because the new reference surface remains Knop-internal
+- keep `alice/_knop/_references/references.ttl` as the working current file while making it match the latest catalog-history snapshot exactly
+
+This task should prove the first real `version + validate + generate` path for a Knop-owned `ReferenceCatalog` without absorbing later Bob extraction, multi-link updates, or richer retired-link rendering work.
+
+## Discussion
+
+### Why this is the next slice
+
+The settled fixture ladder already makes the next carried sequence clear:
+
+- semantic change
+- weave
+
+After `08-alice-bio-referenced`, the next missing implementation-bearing step is the woven reference-catalog case, not the cross-cutting RDF-parsing cleanup task.
+
+Jumping ahead would leave a real gap:
+
+- non-woven managed references would exist
+- but the first explicit `ReferenceCatalog` history, KnopInventory advancement for that catalog, and catalog-facing page-generation path would still be unimplemented
+
+### Why this slice should stay narrow
+
+The settled `09` fixture is specific enough to carry a real slice without reopening the whole weave family.
+
+For `09-alice-bio-referenced-woven`, the current expected behavior is:
+
+- `_mesh/_meta/meta.ttl` stays unchanged
+- `_mesh/_inventory/inventory.ttl` stays unchanged
+- `alice/_knop/_meta/meta.ttl` stays unchanged
+- `alice/_knop/_inventory/inventory.ttl` advances to `_s0002`
+- `alice/_knop/_references/_history001/_s0001/...` appears as the first explicit catalog history
+- `alice/_knop/_references/index.html` and the first catalog-history pages appear
+
+That is enough to prove:
+
+- first `ReferenceCatalog` history creation
+- later-state advancement for an already-versioned Knop-owned support artifact
+- the rule that weaving a Knop-internal reference surface does not widen `_mesh/_inventory`
+- first current-page dereference support for a fragment-identified `ReferenceLink`
+
+### Existing spec posture
+
+This task should reuse [[wd.spec.2026-04-03-weave-behavior]] rather than creating another broad weave spec note immediately.
+
+If this reference-catalog-oriented `weave` slice exposes a missing or ambiguous behavior boundary not already captured there, update the existing weave behavior note rather than spawning overlapping prose.
+
+### ReferenceCatalog page behavior
+
+This slice is the first carried implementation that must make the current catalog page act as the dereference target for the catalog-rooted fragment link.
+
+For the settled `09` Alice Bio case, there is only one current link and no retired links yet, so the implementation should stay narrow:
+
+- render the current `#reference001` anchor on `alice/_knop/_references/index.html`
+- materialize the first catalog history pages and snapshot
+- structure the runtime so later retired-link recovery from history can extend this path rather than replace it
+
+That means the task should prove the first history-aware catalog page shape without pretending the richer retired-link case is already solved.
+
+## Resolved Issues
+
+- The existing weave request shape stayed narrow for this slice; reference-catalog weaving still fits the current local `weave` targeting model.
+- The existing shared runtime page-rendering seam should be extended rather than replaced; `09` is the next carried page family on that seam, not a reason to fork a separate generator path.
+- `_mesh/_inventory` should remain unchanged for this slice because the woven change is Knop-internal support-artifact state, not a new public current-surface mesh member.
+
+## Decisions
+
+- Treat `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` as the next carried implementation slice.
+- Reuse [[wd.spec.2026-04-03-weave-behavior]] as the current behavior spec for this slice.
+- Keep the next `weave` implementation local or in-process over shared `core` and `runtime`.
+- Keep bare top-level `weave` as the local CLI surface for this slice rather than introducing a new `weave weave` spelling.
+- Use the settled Alice Bio `09-alice-bio-referenced-woven` manifest and fixture as the first acceptance target.
+- Keep `_mesh/_inventory/inventory.ttl` unchanged while advancing `alice/_knop/_inventory` to `_s0002`.
+- Version `alice/_knop/_references` into its first explicit history and keep the working `references.ttl` file byte-identical to the latest historical snapshot after weave.
+- Extend the existing shared runtime page-rendering seam to cover current and historical `ReferenceCatalog` pages for this slice.
+- Keep the current `09` catalog page output fixture-first and minimal; defer richer retired-link recovery and multi-link rendering rules to later slices.
+- Keep current local `weave` runtime validation at generated-RDF parse validation for this slice.
+- Do not absorb Bob extraction, multi-link updates, daemon work, or broader rendering ambitions into this task.
+
+## Contract Changes
+
+- No public `weave` contract change should be required for this slice; the existing thin request/result shape should still fit the reference-catalog weave case.
+- This task should not attempt to finalize the full `weave` contract for every future support-artifact type, retired-link behavior, or target-selection mode.
+
+## Testing
+
+- Follow [[wd.testing]].
+- Add failing unit tests for the next narrow weave planning or rendering logic where practical.
+- Add integration tests for local filesystem results against the settled `09-alice-bio-referenced-woven` fixture target.
+- Add a black-box CLI acceptance test scoped by the settled `09-alice-bio-referenced-woven` Accord manifest.
+- Keep the comparison black-box and fixture-oriented rather than coupling tests to internal helper structure.
+
+## Non-Goals
+
+- implementing `10-alice-bio-updated`
+- implementing Bob extraction or `12-bob-extracted`
+- implementing richer retired-link anchor recovery beyond the current one-link fixture
+- implementing multi-link catalogs or batch updates
+- changing the current root working payload file placement
+- implementing daemon endpoints
+- implementing a broad or final HTML renderer system
+- addressing the broader RDF-parsing cleanup task in this slice
+
+## Implementation Plan
+
+- [ ] Confirm whether the existing weave behavior spec is sufficient as-is for the `09` slice.
+- [ ] Define the next local request/result shapes for `weave` in shared `core` and `runtime` if reference-catalog weaving requires a refinement.
+- [ ] Add failing unit and integration tests for the `09` reference-catalog-weave behavior.
+- [ ] Define the minimal shared runtime page-model and HTML-rendering extension needed for current and historical `ReferenceCatalog` pages.
+- [ ] Implement the next local or in-process `weave` path over shared `core` and `runtime`.
+- [ ] Add a black-box CLI acceptance test scoped by the settled `09-alice-bio-referenced-woven` Accord manifest.
+- [ ] Draft or refine the thin public API example or contract fragment for `weave` in `semantic-flow-framework` if this slice sharpens the public contract.
+- [ ] Update relevant overview/spec/framework notes as the slice settles.

--- a/documentation/notes/wd.task.2026.2026-04-04_2019-update-alice-bio-payload.md
+++ b/documentation/notes/wd.task.2026.2026-04-04_2019-update-alice-bio-payload.md
@@ -1,0 +1,129 @@
+---
+id: 36n2frq6aqahs0czp3v6u4as
+title: 2026 04 04 2019 Update Alice Bio Payload
+desc: ''
+updated: 1775359260000
+created: 1775359260000
+---
+
+## Goals
+
+- Carry the next real local semantic slice after [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]].
+- Implement the first local or in-process `payload.update` path over shared `core` and `runtime`.
+- Add a dedicated behavior spec note for `payload.update` rather than leaving this new operation implicit in fixture diffs alone.
+- Keep this first payload-update implementation narrow enough to prove non-woven working-payload replacement behavior without absorbing the later `11-alice-bio-v2-woven` weave responsibilities or a generic RDF patch system.
+
+## Summary
+
+This task should follow the carried local `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` `weave` slice.
+
+The next carried slice should target the settled Alice Bio transition from `09-alice-bio-referenced-woven` to `10-alice-bio-updated`.
+
+The target behavior is deliberately narrow:
+
+- update the existing working payload file `alice-bio.ttl` for the already managed payload artifact `alice/bio`
+- keep the working payload file at the existing root path rather than relocating it before the later woven `v2` slice
+- leave `alice/bio/_history001/_s0001/...` unchanged until the next `weave`
+- leave `_mesh/_inventory/inventory.ttl`, `alice/_knop/_inventory/inventory.ttl`, `alice/_knop/_references/references.ttl`, and `alice/bio/_knop/_inventory/inventory.ttl` unchanged
+- keep the change single-artifact and non-woven: in the settled `09` -> `10` fixture, no file other than `alice-bio.ttl` changes
+
+This task should prove the first semantic payload-update path without folding in `11-alice-bio-v2-woven`, Bob extraction, or generalized RDF-editing abstractions.
+
+## Discussion
+
+### Why this is the next slice
+
+The settled fixture ladder and Accord manifest make the next missing implementation-bearing step explicit:
+
+- semantic change
+- weave
+
+After `09-alice-bio-referenced-woven`, the next carried step is the non-woven payload update, not the later `11` weave and not the cross-cutting RDF-parsing cleanup task.
+
+Jumping straight to `11-alice-bio-v2-woven` would blur the same boundary the fixture ladder is trying to preserve:
+
+- `payload.update` changes the current semantic payload bytes
+- `weave` versions, validates, and regenerates the current surface afterward
+
+### Why this slice should stay narrow
+
+The settled `10-alice-bio-updated` fixture is deliberately clean. The repo diff from `09` to `10` changes only `alice-bio.ttl`.
+
+Within that one-file change, the semantic content shift is still meaningful:
+
+- use explicit mesh-root IRIs like `<alice>` and `<bob>` rather than the prior `:` prefix shorthand
+- add `<alice/bio> dcterms:creator <alice>`
+- expand `<bob>` into a local `schema:Person` description with `foaf:givenName` and `foaf:nick`
+
+At the same time, the first payload snapshot and all current support artifacts remain frozen. That makes this a good carried slice because it proves semantic-update behavior directly without conflating it with versioning, page generation, or extraction behavior.
+
+### Existing spec posture
+
+This slice should get a dedicated [[wd.spec.2026-04-04-payload-update-behavior]] note before implementation.
+
+Unlike `weave`, `integrate`, `knop.create`, and `knop.addReference`, there is no current behavior note for `payload.update`, and this is a distinct manifest-backed operation with its own machine-facing name.
+
+The existing [[wd.spec.2026-04-04-integrate-behavior]] and [[wd.spec.2026-04-03-weave-behavior]] notes should be treated as neighboring context, not as a substitute for a real `payload.update` behavior note.
+
+### Working-file posture
+
+The first carried `payload.update` slice should update the bytes of the already managed working payload file in place.
+
+That means:
+
+- the target designator should already resolve to an existing integrated payload artifact
+- the local runtime should resolve the existing working located file for that payload artifact
+- the current slice should not invent a patch language, relocate the working file, or create a new historical snapshot before the later `11` weave
+
+## Resolved Questions
+
+- The machine-facing job kind and manifest `operationId` should stay `payload.update`.
+- `payload.update` should get a dedicated `wd.spec.*` note before implementation rather than being folded into the weave note.
+- The first local request/result boundary should stay narrow around an existing payload `designatorPath` plus a replacement source input, while keeping host staging and file-replacement details in the local runtime rather than shared `core`.
+- The first carried slice should update the existing working payload bytes in place rather than introducing a general RDF diff or patch abstraction.
+- The current local validation floor should stay narrow: changed RDF should parse cleanly and match the settled fixture semantics, while broader merged-graph or SHACL validation remains a later concern.
+
+## Decisions
+
+- Treat `09-alice-bio-referenced-woven` -> `10-alice-bio-updated` as the next carried implementation slice.
+- Use the settled Alice Bio `10-alice-bio-updated` manifest and fixture as the first acceptance target.
+- Add a dedicated [[wd.spec.2026-04-04-payload-update-behavior]] note for this slice.
+- Keep the first `payload.update` implementation local or in-process over shared `core` and `runtime`.
+- Keep the slice single-artifact and non-woven: in the settled acceptance target, only `alice-bio.ttl` should change.
+- Preserve the current working file placement at `alice-bio.ttl` for this first slice.
+- Leave `alice/bio/_history001/_s0001/...`, `_mesh/_inventory/inventory.ttl`, `alice/_knop/_inventory/inventory.ttl`, `alice/_knop/_references/references.ttl`, and `alice/bio/_knop/_inventory/inventory.ttl` unchanged in this non-woven step.
+- Do not absorb `11-alice-bio-v2-woven`, Bob extraction, generic RDF patching, daemon work, or broader rendering ambitions into this task.
+
+## Contract Changes
+
+- This task may introduce the first thin public request/result examples for `payload.update` in `semantic-flow-framework`.
+- This task should not broaden the public contract into a generic RDF-editing, merge, or patch API beyond what the carried `09` -> `10` slice actually proves.
+
+## Testing
+
+- Follow [[wd.testing]].
+- Add failing unit tests for narrow `payload.update` planning and validation logic where practical.
+- Add integration tests for local filesystem results against the settled `10-alice-bio-updated` fixture target.
+- Add a black-box CLI acceptance test scoped by the settled `10-alice-bio-updated` Accord manifest.
+- Keep the comparison black-box and fixture-oriented, with strong checks that untouched support artifacts remain unchanged.
+
+## Non-Goals
+
+- implementing `11-alice-bio-v2-woven`
+- creating a new payload historical state under `alice/bio/_history001/...`
+- updating `_mesh/_inventory` or any Knop inventory in this non-woven step
+- generating or regenerating HTML pages
+- creating `bob/_knop` support artifacts or performing Bob extraction
+- introducing a generic RDF diff, merge, or patch language
+- relocating `alice-bio.ttl`
+- implementing daemon endpoints
+
+## Implementation Plan
+
+- [ ] Draft [[wd.spec.2026-04-04-payload-update-behavior]] and settle the first local request/result boundary for `payload.update`.
+- [ ] Define the first local CLI surface for the carried `payload.update` operation.
+- [ ] Add failing unit and integration tests for the narrow `09` -> `10` payload-update behavior.
+- [ ] Implement the first local or in-process `payload.update` path over shared `core` and `runtime`.
+- [ ] Add a black-box CLI acceptance test scoped by the settled `10-alice-bio-updated` Accord manifest.
+- [ ] Draft or refine the thin public API example or contract fragment for `payload.update` in `semantic-flow-framework` if this slice sharpens the public contract.
+- [ ] Update relevant overview/spec/framework notes as the slice settles.

--- a/documentation/notes/wd.todo.md
+++ b/documentation/notes/wd.todo.md
@@ -9,4 +9,5 @@ created: 1774046031081
 ## Current Priorities
 
 - [ ] [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]]
+- [ ] [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]]
 - [ ] [[wd.task.2026.2026-04-04_0952-rdf-parsing]]

--- a/documentation/notes/wd.todo.md
+++ b/documentation/notes/wd.todo.md
@@ -8,4 +8,5 @@ created: 1774046031081
 
 ## Current Priorities
 
+- [ ] [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]]
 - [ ] [[wd.task.2026.2026-04-04_0952-rdf-parsing]]

--- a/documentation/notes/wd.todo.md
+++ b/documentation/notes/wd.todo.md
@@ -8,5 +8,4 @@ created: 1774046031081
 
 ## Current Priorities
 
-- [ ] [[wd.task.2026.2026-04-04-alice-bio-referenced]]
 - [ ] [[wd.task.2026.2026-04-04_0952-rdf-parsing]]

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command";
 import { Input } from "@cliffy/prompt";
 import { join, resolve } from "@std/path";
 import { IntegrateInputError } from "../core/integrate/integrate.ts";
+import { KnopAddReferenceInputError } from "../core/knop/add_reference.ts";
 import { KnopCreateInputError } from "../core/knop/create.ts";
 import { MeshCreateInputError } from "../core/mesh/create.ts";
 import { WeaveInputError } from "../core/weave/weave.ts";
@@ -11,6 +12,11 @@ import {
   executeIntegrate,
   IntegrateRuntimeError,
 } from "../runtime/integrate/integrate.ts";
+import {
+  describeKnopAddReferenceResult,
+  executeKnopAddReference,
+  KnopAddReferenceRuntimeError,
+} from "../runtime/knop/add_reference.ts";
 import {
   describeKnopCreateResult,
   executeKnopCreate,
@@ -170,6 +176,68 @@ export async function runWeaveCli(args: string[]): Promise<number> {
       new Command()
         .description("Knop operations.")
         .command(
+          "add-reference",
+          new Command()
+            .description(
+              "Create the first reference-catalog surface for a designator path.",
+            )
+            .arguments("<designatorPath:string>")
+            .option(
+              "--reference-target-designator-path <referenceTargetDesignatorPath:string>",
+              "Designator path of the existing mesh resource used as the reference target.",
+            )
+            .option(
+              "--reference-role <referenceRole:string>",
+              "ReferenceRole token to assign to the created ReferenceLink.",
+            )
+            .option(
+              "--workspace <workspace:string>",
+              "Workspace root to update.",
+              { default: "." },
+            )
+            .action(async (options, designatorPath) => {
+              const workspaceRoot = resolve(options.workspace);
+              const referenceTargetDesignatorPath = resolveRequiredOptionValue(
+                options.referenceTargetDesignatorPath,
+                "knop add-reference requires --reference-target-designator-path",
+              );
+              const referenceRole = resolveRequiredOptionValue(
+                options.referenceRole,
+                "knop add-reference requires --reference-role",
+              );
+              const logDir = join(workspaceRoot, ".weave", "logs");
+              const { operationalLogger, auditLogger } = createRuntimeLoggers({
+                logDir,
+              });
+
+              await auditLogger.command("knop.addReference", {
+                workspaceRoot,
+                designatorPath,
+                referenceTargetDesignatorPath,
+                referenceRole,
+                localMode: true,
+              });
+
+              const result = await executeKnopAddReference({
+                workspaceRoot,
+                request: {
+                  designatorPath,
+                  referenceTargetDesignatorPath,
+                  referenceRole,
+                },
+                operationalLogger,
+                auditLogger,
+              });
+              console.log(describeKnopAddReferenceResult(result));
+              for (const path of result.createdPaths) {
+                console.log(path);
+              }
+              for (const path of result.updatedPaths) {
+                console.log(path);
+              }
+            }),
+        )
+        .command(
           "create",
           new Command()
             .description(
@@ -281,6 +349,8 @@ function getCliErrorMessage(error: unknown): string {
   if (
     error instanceof IntegrateInputError ||
     error instanceof IntegrateRuntimeError ||
+    error instanceof KnopAddReferenceInputError ||
+    error instanceof KnopAddReferenceRuntimeError ||
     error instanceof WeaveInputError ||
     error instanceof WeaveRuntimeError ||
     error instanceof KnopCreateInputError ||
@@ -294,4 +364,15 @@ function getCliErrorMessage(error: unknown): string {
     return error.message.trim();
   }
   return String(error);
+}
+
+function resolveRequiredOptionValue(
+  value: string | undefined,
+  errorMessage: string,
+): string {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.length === 0) {
+    throw new KnopAddReferenceInputError(errorMessage);
+  }
+  return trimmed;
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -196,6 +196,10 @@ export async function runWeaveCli(args: string[]): Promise<number> {
               { default: "." },
             )
             .action(async (options, designatorPath) => {
+              const normalizedDesignatorPath = resolveRequiredArgumentValue(
+                designatorPath,
+                "knop add-reference requires a positional designatorPath",
+              );
               const workspaceRoot = resolve(options.workspace);
               const referenceTargetDesignatorPath = resolveRequiredOptionValue(
                 options.referenceTargetDesignatorPath,
@@ -212,7 +216,7 @@ export async function runWeaveCli(args: string[]): Promise<number> {
 
               await auditLogger.command("knop.addReference", {
                 workspaceRoot,
-                designatorPath,
+                designatorPath: normalizedDesignatorPath,
                 referenceTargetDesignatorPath,
                 referenceRole,
                 localMode: true,
@@ -221,7 +225,7 @@ export async function runWeaveCli(args: string[]): Promise<number> {
               const result = await executeKnopAddReference({
                 workspaceRoot,
                 request: {
-                  designatorPath,
+                  designatorPath: normalizedDesignatorPath,
                   referenceTargetDesignatorPath,
                   referenceRole,
                 },
@@ -375,4 +379,14 @@ function resolveRequiredOptionValue(
     throw new KnopAddReferenceInputError(errorMessage);
   }
   return trimmed;
+}
+
+function resolveRequiredArgumentValue(
+  value: string | undefined,
+  errorMessage: string,
+): string {
+  return resolveRequiredOptionValue(
+    typeof value === "string" ? value : undefined,
+    errorMessage,
+  );
 }

--- a/src/core/knop/add_reference.ts
+++ b/src/core/knop/add_reference.ts
@@ -1,0 +1,331 @@
+import type { PlannedFile } from "../planned_file.ts";
+
+const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
+
+const referenceRoleIriByToken = {
+  canonical:
+    "https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Canonical",
+  supplemental:
+    "https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Supplemental",
+  deprecated:
+    "https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Deprecated",
+} as const;
+
+type ReferenceRoleToken = keyof typeof referenceRoleIriByToken;
+
+export interface KnopAddReferenceRequest {
+  designatorPath: string;
+  referenceTargetDesignatorPath: string;
+  referenceRole: string;
+}
+
+export interface ResolvedKnopAddReferenceRequest
+  extends KnopAddReferenceRequest {
+  meshBase: string;
+  currentKnopInventoryTurtle: string;
+}
+
+export interface KnopAddReferencePlan {
+  meshBase: string;
+  designatorPath: string;
+  referenceTargetDesignatorPath: string;
+  referenceCatalogIri: string;
+  referenceLinkIri: string;
+  referenceRoleIri: string;
+  referenceTargetIri: string;
+  createdFiles: readonly PlannedFile[];
+  updatedFiles: readonly PlannedFile[];
+}
+
+export class KnopAddReferenceInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "KnopAddReferenceInputError";
+  }
+}
+
+export function planKnopAddReference(
+  request: ResolvedKnopAddReferenceRequest,
+): KnopAddReferencePlan {
+  const meshBase = normalizeMeshBase(request.meshBase);
+  const designatorPath = normalizeDesignatorPath(request.designatorPath);
+  const referenceTargetDesignatorPath = normalizeDesignatorPath(
+    request.referenceTargetDesignatorPath,
+  );
+  const referenceRoleToken = normalizeReferenceRole(request.referenceRole);
+  const referenceRoleIri = referenceRoleIriByToken[referenceRoleToken];
+  const knopPath = toKnopPath(designatorPath);
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const referenceLinkPath = `${referenceCatalogPath}#reference001`;
+
+  return {
+    meshBase,
+    designatorPath,
+    referenceTargetDesignatorPath,
+    referenceCatalogIri: new URL(referenceCatalogPath, meshBase).href,
+    referenceLinkIri: new URL(referenceLinkPath, meshBase).href,
+    referenceRoleIri,
+    referenceTargetIri: new URL(referenceTargetDesignatorPath, meshBase).href,
+    createdFiles: [
+      {
+        path: `${referenceCatalogPath}/references.ttl`,
+        contents: renderReferencesTurtle(
+          meshBase,
+          designatorPath,
+          referenceTargetDesignatorPath,
+          referenceRoleIri,
+        ),
+      },
+    ],
+    updatedFiles: [
+      {
+        path: `${knopPath}/_inventory/inventory.ttl`,
+        contents: renderUpdatedKnopInventoryTurtle(
+          request.currentKnopInventoryTurtle,
+          knopPath,
+        ),
+      },
+    ],
+  };
+}
+
+function normalizeMeshBase(meshBase: string): string {
+  const trimmed = meshBase.trim();
+  if (trimmed.length === 0) {
+    throw new KnopAddReferenceInputError("meshBase is required");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new KnopAddReferenceInputError("meshBase must be an absolute IRI");
+  }
+
+  if (!url.pathname.endsWith("/")) {
+    throw new KnopAddReferenceInputError("meshBase must end with '/'");
+  }
+  if (url.search.length > 0 || url.hash.length > 0) {
+    throw new KnopAddReferenceInputError(
+      "meshBase must not include a query or fragment",
+    );
+  }
+
+  return url.href;
+}
+
+function normalizeDesignatorPath(designatorPath: string): string {
+  const trimmed = designatorPath.trim();
+  if (trimmed.length === 0) {
+    throw new KnopAddReferenceInputError("designatorPath is required");
+  }
+  if (trimmed.startsWith("/") || trimmed.endsWith("/")) {
+    throw new KnopAddReferenceInputError(
+      "designatorPath must not start or end with '/'",
+    );
+  }
+  if (
+    trimmed.includes("\\") || trimmed.includes("?") || trimmed.includes("#")
+  ) {
+    throw new KnopAddReferenceInputError(
+      "designatorPath contains unsupported path characters",
+    );
+  }
+
+  const segments = trimmed.split("/");
+  if (segments.some((segment) => segment.length === 0)) {
+    throw new KnopAddReferenceInputError(
+      "designatorPath must not contain empty path segments",
+    );
+  }
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new KnopAddReferenceInputError(
+      "designatorPath must not contain '.' or '..' path segments",
+    );
+  }
+  if (segments.some((segment) => reservedDesignatorSegments.has(segment))) {
+    throw new KnopAddReferenceInputError(
+      "designatorPath must not contain reserved path segments",
+    );
+  }
+
+  return trimmed;
+}
+
+function normalizeReferenceRole(referenceRole: string): ReferenceRoleToken {
+  const normalized = referenceRole.trim().toLowerCase();
+  if (normalized.length === 0) {
+    throw new KnopAddReferenceInputError("referenceRole is required");
+  }
+  if (normalized in referenceRoleIriByToken) {
+    return normalized as ReferenceRoleToken;
+  }
+  throw new KnopAddReferenceInputError(
+    `Unsupported referenceRole: ${referenceRole}`,
+  );
+}
+
+function renderReferencesTurtle(
+  meshBase: string,
+  designatorPath: string,
+  referenceTargetDesignatorPath: string,
+  referenceRoleIri: string,
+): string {
+  const referenceCatalogPath = `${toKnopPath(designatorPath)}/_references`;
+
+  return `@base <${meshBase}> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+
+<${designatorPath}> sflo:hasReferenceLink <${referenceCatalogPath}#reference001> .
+
+<${referenceCatalogPath}#reference001> a sflo:ReferenceLink ;
+  sflo:referenceLinkFor <${designatorPath}> ;
+  sflo:hasReferenceRole <${referenceRoleIri}> ;
+  sflo:referenceTarget <${referenceTargetDesignatorPath}> .
+`;
+}
+
+function renderUpdatedKnopInventoryTurtle(
+  currentKnopInventoryTurtle: string,
+  knopPath: string,
+): string {
+  const referenceCatalogPath = `${knopPath}/_references`;
+
+  if (
+    currentKnopInventoryTurtle.includes(
+      `sflo:hasReferenceCatalog <${referenceCatalogPath}>`,
+    ) ||
+    currentKnopInventoryTurtle.includes(
+      `<${referenceCatalogPath}> a sflo:ReferenceCatalog`,
+    )
+  ) {
+    throw new KnopAddReferenceInputError(
+      `knop inventory already registers reference catalog: ${referenceCatalogPath}`,
+    );
+  }
+
+  const lines = currentKnopInventoryTurtle.split("\n");
+
+  insertReferenceCatalogIntoKnopBlock(lines, knopPath);
+  insertReferenceCatalogBlock(lines, knopPath);
+  insertReferenceCatalogLocatedFile(lines, knopPath);
+
+  return lines.join("\n");
+}
+
+function insertReferenceCatalogIntoKnopBlock(
+  lines: string[],
+  knopPath: string,
+): void {
+  const knopLineIndex = lines.indexOf(`<${knopPath}> a sflo:Knop ;`);
+  if (knopLineIndex === -1) {
+    throw new KnopAddReferenceInputError(
+      `current knop inventory is missing the ${knopPath} block`,
+    );
+  }
+
+  let lastPredicateIndex = knopLineIndex + 1;
+  while (
+    lastPredicateIndex < lines.length &&
+    lines[lastPredicateIndex].startsWith("  ")
+  ) {
+    lastPredicateIndex += 1;
+  }
+  lastPredicateIndex -= 1;
+
+  if (lastPredicateIndex <= knopLineIndex) {
+    throw new KnopAddReferenceInputError(
+      "current knop inventory has an invalid knop block",
+    );
+  }
+
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const lastPredicateLine = lines[lastPredicateIndex];
+
+  if (lastPredicateLine.includes("sflo:hasResourcePage")) {
+    lines.splice(
+      lastPredicateIndex,
+      0,
+      `  sflo:hasReferenceCatalog <${referenceCatalogPath}> ;`,
+    );
+    return;
+  }
+
+  lines[lastPredicateIndex] = lastPredicateLine.replace(/\.\s*$/, " ;");
+  lines.splice(
+    lastPredicateIndex + 1,
+    0,
+    `  sflo:hasReferenceCatalog <${referenceCatalogPath}> .`,
+  );
+}
+
+function insertReferenceCatalogBlock(lines: string[], knopPath: string): void {
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const inventoryHistoryIndex = lines.findIndex((line) =>
+    line.startsWith(`<${knopPath}/_inventory/_history`)
+  );
+  const metaLocatedFileIndex = lines.indexOf(
+    `<${knopPath}/_meta/meta.ttl> a sflo:LocatedFile, sflo:RdfDocument .`,
+  );
+
+  const insertionIndex = inventoryHistoryIndex >= 0
+    ? inventoryHistoryIndex
+    : metaLocatedFileIndex >= 0
+    ? metaLocatedFileIndex
+    : lines.length;
+
+  spliceSeparatedBlock(
+    lines,
+    insertionIndex,
+    [
+      `<${referenceCatalogPath}> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;`,
+      `  sflo:hasWorkingLocatedFile <${referenceCatalogPath}/references.ttl> .`,
+    ],
+  );
+}
+
+function insertReferenceCatalogLocatedFile(
+  lines: string[],
+  knopPath: string,
+): void {
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const historyLocatedFileIndex = lines.findIndex((line) =>
+    (
+      line.startsWith(`<${knopPath}/_meta/_history`) ||
+      line.startsWith(`<${knopPath}/_inventory/_history`)
+    ) && line.includes("a sflo:LocatedFile")
+  );
+
+  const insertionIndex = historyLocatedFileIndex >= 0
+    ? historyLocatedFileIndex
+    : lines.length > 0 && lines[lines.length - 1] === ""
+    ? lines.length - 1
+    : lines.length;
+
+  spliceSeparatedBlock(
+    lines,
+    insertionIndex,
+    [`<${referenceCatalogPath}/references.ttl> a sflo:LocatedFile, sflo:RdfDocument .`],
+  );
+}
+
+function spliceSeparatedBlock(
+  lines: string[],
+  insertionIndex: number,
+  blockLines: readonly string[],
+): void {
+  const entries = [...blockLines];
+
+  if (insertionIndex > 0 && lines[insertionIndex - 1] !== "") {
+    entries.unshift("");
+  }
+  if (insertionIndex < lines.length && lines[insertionIndex] !== "") {
+    entries.push("");
+  }
+
+  lines.splice(insertionIndex, 0, ...entries);
+}
+
+function toKnopPath(designatorPath: string): string {
+  return `${designatorPath}/_knop`;
+}

--- a/src/core/knop/add_reference.ts
+++ b/src/core/knop/add_reference.ts
@@ -1,6 +1,7 @@
 import type { PlannedFile } from "../planned_file.ts";
 
 const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
+const safeDesignatorSegmentPattern = /^[A-Za-z0-9._-]+$/;
 
 const referenceRoleIriByToken = {
   canonical:
@@ -48,9 +49,13 @@ export function planKnopAddReference(
   request: ResolvedKnopAddReferenceRequest,
 ): KnopAddReferencePlan {
   const meshBase = normalizeMeshBase(request.meshBase);
-  const designatorPath = normalizeDesignatorPath(request.designatorPath);
+  const designatorPath = normalizeDesignatorPath(
+    request.designatorPath,
+    "designatorPath",
+  );
   const referenceTargetDesignatorPath = normalizeDesignatorPath(
     request.referenceTargetDesignatorPath,
+    "referenceTargetDesignatorPath",
   );
   const referenceRoleToken = normalizeReferenceRole(request.referenceRole);
   const referenceRoleIri = referenceRoleIriByToken[referenceRoleToken];
@@ -114,39 +119,49 @@ function normalizeMeshBase(meshBase: string): string {
   return url.href;
 }
 
-function normalizeDesignatorPath(designatorPath: string): string {
+function normalizeDesignatorPath(
+  designatorPath: string,
+  fieldName: string,
+): string {
   const trimmed = designatorPath.trim();
   if (trimmed.length === 0) {
-    throw new KnopAddReferenceInputError("designatorPath is required");
+    throw new KnopAddReferenceInputError(`${fieldName} is required`);
   }
   if (trimmed.startsWith("/") || trimmed.endsWith("/")) {
     throw new KnopAddReferenceInputError(
-      "designatorPath must not start or end with '/'",
+      `${fieldName} must not start or end with '/'`,
     );
   }
   if (
     trimmed.includes("\\") || trimmed.includes("?") || trimmed.includes("#")
   ) {
     throw new KnopAddReferenceInputError(
-      "designatorPath contains unsupported path characters",
+      `${fieldName} contains unsupported path characters`,
     );
   }
 
   const segments = trimmed.split("/");
   if (segments.some((segment) => segment.length === 0)) {
     throw new KnopAddReferenceInputError(
-      "designatorPath must not contain empty path segments",
+      `${fieldName} must not contain empty path segments`,
     );
   }
   if (segments.some((segment) => segment === "." || segment === "..")) {
     throw new KnopAddReferenceInputError(
-      "designatorPath must not contain '.' or '..' path segments",
+      `${fieldName} must not contain '.' or '..' path segments`,
     );
   }
   if (segments.some((segment) => reservedDesignatorSegments.has(segment))) {
     throw new KnopAddReferenceInputError(
-      "designatorPath must not contain reserved path segments",
+      `${fieldName} must not contain reserved path segments`,
     );
+  }
+  for (const segment of segments) {
+    if (!safeDesignatorSegmentPattern.test(segment)) {
+      throw new KnopAddReferenceInputError(
+        `normalizeDesignatorPath rejected segment "${segment}" in ${fieldName}: toKnopPath only accepts path segments matching [A-Za-z0-9._-]+`,
+      );
+    }
   }
 
   return trimmed;
@@ -157,7 +172,9 @@ function normalizeReferenceRole(referenceRole: string): ReferenceRoleToken {
   if (normalized.length === 0) {
     throw new KnopAddReferenceInputError("referenceRole is required");
   }
-  if (normalized in referenceRoleIriByToken) {
+  if (
+    Object.prototype.hasOwnProperty.call(referenceRoleIriByToken, normalized)
+  ) {
     return normalized as ReferenceRoleToken;
   }
   throw new KnopAddReferenceInputError(

--- a/src/core/knop/add_reference_test.ts
+++ b/src/core/knop/add_reference_test.ts
@@ -1,0 +1,190 @@
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import {
+  KnopAddReferenceInputError,
+  planKnopAddReference,
+} from "./add_reference.ts";
+
+const wovenKnopInventory =
+  `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<alice/_knop> a sflo:Knop ;
+  sflo:hasKnopMetadata <alice/_knop/_meta> ;
+  sflo:hasKnopInventory <alice/_knop/_inventory> ;
+  sflo:hasWorkingKnopInventoryFile <alice/_knop/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <alice/_knop/index.html> .
+
+<alice/_knop/_meta> a sflo:KnopMetadata, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <alice/_knop/_meta/_history001> ;
+  sflo:currentArtifactHistory <alice/_knop/_meta/_history001> ;
+  sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasWorkingLocatedFile <alice/_knop/_meta/meta.ttl> ;
+  sflo:hasResourcePage <alice/_knop/_meta/index.html> .
+
+<alice/_knop/_meta/_history001> a sflo:ArtifactHistory ;
+  sflo:historyOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasHistoricalState <alice/_knop/_meta/_history001/_s0001> ;
+  sflo:latestHistoricalState <alice/_knop/_meta/_history001/_s0001> ;
+  sflo:nextStateOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasResourcePage <alice/_knop/_meta/_history001/index.html> .
+
+<alice/_knop/_meta/_history001/_s0001> a sflo:HistoricalState ;
+  sflo:stateOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasManifestation <alice/_knop/_meta/_history001/_s0001/meta-ttl> ;
+  sflo:locatedFileForState <alice/_knop/_meta/_history001/_s0001/meta-ttl/meta.ttl> ;
+  sflo:hasResourcePage <alice/_knop/_meta/_history001/_s0001/index.html> .
+
+<alice/_knop/_meta/_history001/_s0001/meta-ttl> a sflo:ArtifactManifestation, sflo:RdfDocument ;
+  sflo:hasLocatedFile <alice/_knop/_meta/_history001/_s0001/meta-ttl/meta.ttl> ;
+  sflo:hasResourcePage <alice/_knop/_meta/_history001/_s0001/meta-ttl/index.html> .
+
+<alice/_knop/_inventory> a sflo:KnopInventory, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <alice/_knop/_inventory/_history001> ;
+  sflo:currentArtifactHistory <alice/_knop/_inventory/_history001> ;
+  sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasWorkingLocatedFile <alice/_knop/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <alice/_knop/_inventory/index.html> .
+
+<alice/_knop/_inventory/_history001> a sflo:ArtifactHistory ;
+  sflo:historyOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasHistoricalState <alice/_knop/_inventory/_history001/_s0001> ;
+  sflo:latestHistoricalState <alice/_knop/_inventory/_history001/_s0001> ;
+  sflo:nextStateOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasResourcePage <alice/_knop/_inventory/_history001/index.html> .
+
+<alice/_knop/_inventory/_history001/_s0001> a sflo:HistoricalState ;
+  sflo:stateOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasManifestation <alice/_knop/_inventory/_history001/_s0001/inventory-ttl> ;
+  sflo:locatedFileForState <alice/_knop/_inventory/_history001/_s0001/inventory-ttl/inventory.ttl> ;
+  sflo:hasResourcePage <alice/_knop/_inventory/_history001/_s0001/index.html> .
+
+<alice/_knop/_inventory/_history001/_s0001/inventory-ttl> a sflo:ArtifactManifestation, sflo:RdfDocument ;
+  sflo:hasLocatedFile <alice/_knop/_inventory/_history001/_s0001/inventory-ttl/inventory.ttl> ;
+  sflo:hasResourcePage <alice/_knop/_inventory/_history001/_s0001/inventory-ttl/index.html> .
+
+<alice/_knop/_meta/meta.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<alice/_knop/_inventory/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<alice/_knop/_meta/_history001/_s0001/meta-ttl/meta.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<alice/_knop/_inventory/_history001/_s0001/inventory-ttl/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<alice/_knop/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_meta/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_meta/_history001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_meta/_history001/_s0001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_meta/_history001/_s0001/meta-ttl/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_inventory/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_inventory/_history001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_inventory/_history001/_s0001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/_knop/_inventory/_history001/_s0001/inventory-ttl/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+`;
+
+Deno.test("planKnopAddReference renders first reference catalog support artifacts", () => {
+  const plan = planKnopAddReference({
+    meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+    designatorPath: "alice",
+    referenceTargetDesignatorPath: "alice/bio",
+    referenceRole: "canonical",
+    currentKnopInventoryTurtle: wovenKnopInventory,
+  });
+
+  assertEquals(
+    plan.referenceCatalogIri,
+    "https://semantic-flow.github.io/mesh-alice-bio/alice/_knop/_references",
+  );
+  assertEquals(
+    plan.referenceLinkIri,
+    "https://semantic-flow.github.io/mesh-alice-bio/alice/_knop/_references#reference001",
+  );
+  assertEquals(
+    plan.referenceRoleIri,
+    "https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Canonical",
+  );
+  assertEquals(
+    plan.createdFiles.map((file) => file.path),
+    ["alice/_knop/_references/references.ttl"],
+  );
+  assertEquals(
+    plan.updatedFiles.map((file) => file.path),
+    ["alice/_knop/_inventory/inventory.ttl"],
+  );
+  assertStringIncludes(
+    plan.createdFiles[0]?.contents ?? "",
+    "<alice> sflo:hasReferenceLink <alice/_knop/_references#reference001> .",
+  );
+  assertStringIncludes(
+    plan.createdFiles[0]?.contents ?? "",
+    "sflo:hasReferenceRole <https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Canonical> ;",
+  );
+  assertStringIncludes(
+    plan.updatedFiles[0]?.contents ?? "",
+    "  sflo:hasReferenceCatalog <alice/_knop/_references> ;",
+  );
+  assertStringIncludes(
+    plan.updatedFiles[0]?.contents ?? "",
+    "<alice/_knop/_references> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;",
+  );
+});
+
+Deno.test("planKnopAddReference normalizes referenceRole tokens case-insensitively", () => {
+  const plan = planKnopAddReference({
+    meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+    designatorPath: "alice",
+    referenceTargetDesignatorPath: "alice/bio",
+    referenceRole: "Supplemental",
+    currentKnopInventoryTurtle: wovenKnopInventory,
+  });
+
+  assertEquals(
+    plan.referenceRoleIri,
+    "https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Supplemental",
+  );
+  assertStringIncludes(
+    plan.createdFiles[0]?.contents ?? "",
+    "sflo:hasReferenceRole <https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Supplemental> ;",
+  );
+});
+
+Deno.test("planKnopAddReference rejects unsupported reference roles", () => {
+  assertThrows(
+    () =>
+      planKnopAddReference({
+        meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+        designatorPath: "alice",
+        referenceTargetDesignatorPath: "alice/bio",
+        referenceRole: "primary",
+        currentKnopInventoryTurtle: wovenKnopInventory,
+      }),
+    KnopAddReferenceInputError,
+    "Unsupported referenceRole",
+  );
+});
+
+Deno.test("planKnopAddReference rejects an already-registered reference catalog", () => {
+  assertThrows(
+    () =>
+      planKnopAddReference({
+        meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+        designatorPath: "alice",
+        referenceTargetDesignatorPath: "alice/bio",
+        referenceRole: "canonical",
+        currentKnopInventoryTurtle: wovenKnopInventory.replace(
+          "  sflo:hasResourcePage <alice/_knop/index.html> .",
+          "  sflo:hasReferenceCatalog <alice/_knop/_references> ;\n  sflo:hasResourcePage <alice/_knop/index.html> .\n\n<alice/_knop/_references> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;\n  sflo:hasWorkingLocatedFile <alice/_knop/_references/references.ttl> .",
+        ),
+      }),
+    KnopAddReferenceInputError,
+    "already registers reference catalog",
+  );
+});

--- a/src/core/knop/add_reference_test.ts
+++ b/src/core/knop/add_reference_test.ts
@@ -171,6 +171,36 @@ Deno.test("planKnopAddReference rejects unsupported reference roles", () => {
   );
 });
 
+Deno.test("planKnopAddReference rejects prototype property reference roles", () => {
+  assertThrows(
+    () =>
+      planKnopAddReference({
+        meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+        designatorPath: "alice",
+        referenceTargetDesignatorPath: "alice/bio",
+        referenceRole: "constructor",
+        currentKnopInventoryTurtle: wovenKnopInventory,
+      }),
+    KnopAddReferenceInputError,
+    "Unsupported referenceRole",
+  );
+});
+
+Deno.test("planKnopAddReference rejects unsafe designator segments before building IRIs", () => {
+  assertThrows(
+    () =>
+      planKnopAddReference({
+        meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+        designatorPath: "alice:bio",
+        referenceTargetDesignatorPath: "alice/bio",
+        referenceRole: "canonical",
+        currentKnopInventoryTurtle: wovenKnopInventory,
+      }),
+    KnopAddReferenceInputError,
+    'normalizeDesignatorPath rejected segment "alice:bio"',
+  );
+});
+
 Deno.test("planKnopAddReference rejects an already-registered reference catalog", () => {
   assertThrows(
     () =>

--- a/src/core/knop/mod.ts
+++ b/src/core/knop/mod.ts
@@ -1,1 +1,2 @@
 export * from "./create.ts";
+export * from "./add_reference.ts";

--- a/src/runtime/knop/add_reference.ts
+++ b/src/runtime/knop/add_reference.ts
@@ -120,40 +120,25 @@ export async function executeKnopAddReference(
     await applyPlanAtomically(workspaceRoot, plan);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    await operationalLogger.error(
-      "knop.addReference.failed",
-      "Local knop add-reference failed",
-      {
-        workspaceRoot,
-        designatorPath,
-        referenceTargetDesignatorPath,
-        referenceRole,
-        referenceCatalogIri: plan?.referenceCatalogIri,
-        referenceLinkIri: plan?.referenceLinkIri,
-        error: message,
-      },
-    );
-    await auditLogger.record(
-      "knop.addReference.failed",
-      "Local knop add-reference failed",
-      {
-        workspaceRoot,
-        designatorPath,
-        referenceTargetDesignatorPath,
-        referenceRole,
-        referenceCatalogIri: plan?.referenceCatalogIri,
-        referenceLinkIri: plan?.referenceLinkIri,
-        error: message,
-      },
+    const originalError = (
+        error instanceof KnopAddReferenceInputError ||
+        error instanceof KnopAddReferenceRuntimeError
+      )
+      ? error
+      : new KnopAddReferenceRuntimeError(message);
+
+    await logKnopAddReferenceFailedBestEffort(
+      operationalLogger,
+      auditLogger,
+      workspaceRoot,
+      designatorPath,
+      referenceTargetDesignatorPath,
+      referenceRole,
+      plan,
+      message,
     );
 
-    if (
-      error instanceof KnopAddReferenceInputError ||
-      error instanceof KnopAddReferenceRuntimeError
-    ) {
-      throw error;
-    }
-    throw new KnopAddReferenceRuntimeError(message);
+    throw originalError;
   }
 
   const result: KnopAddReferenceResult = {
@@ -499,7 +484,7 @@ async function commitStagedPlanMutation(
   }
 
   for (const file of stagedPlanMutation.updatedFiles) {
-    await Deno.rename(file.absolutePath, file.backupPath!);
+    await Deno.copyFile(file.absolutePath, file.backupPath!);
     await Deno.rename(file.tempPath, file.absolutePath);
   }
 }
@@ -591,6 +576,47 @@ async function removeEmptyDirectoriesBestEffort(
     } catch {
       // Rollback cleanup should not obscure the primary result.
     }
+  }
+}
+
+async function logKnopAddReferenceFailedBestEffort(
+  operationalLogger: StructuredLogger,
+  auditLogger: AuditLogger,
+  workspaceRoot: string,
+  designatorPath: string,
+  referenceTargetDesignatorPath: string,
+  referenceRole: string,
+  plan: KnopAddReferencePlan | undefined,
+  errorMessage: string,
+): Promise<void> {
+  const attributes = {
+    workspaceRoot,
+    designatorPath,
+    referenceTargetDesignatorPath,
+    referenceRole,
+    referenceCatalogIri: plan?.referenceCatalogIri,
+    referenceLinkIri: plan?.referenceLinkIri,
+    error: errorMessage,
+  };
+
+  try {
+    await operationalLogger.error(
+      "knop.addReference.failed",
+      "Local knop add-reference failed",
+      attributes,
+    );
+  } catch {
+    // Failure logging must not mask the original add-reference error.
+  }
+
+  try {
+    await auditLogger.record(
+      "knop.addReference.failed",
+      "Local knop add-reference failed",
+      attributes,
+    );
+  } catch {
+    // Failure logging must not mask the original add-reference error.
   }
 }
 

--- a/src/runtime/knop/add_reference.ts
+++ b/src/runtime/knop/add_reference.ts
@@ -1,0 +1,384 @@
+import { dirname, join } from "@std/path";
+import {
+  KnopAddReferenceInputError,
+  type KnopAddReferencePlan,
+  planKnopAddReference,
+} from "../../core/knop/add_reference.ts";
+import { resolveRuntimeLoggers } from "../logging/factory.ts";
+import type { AuditLogger } from "../logging/audit_logger.ts";
+import type { StructuredLogger } from "../logging/logger.ts";
+
+const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
+
+export interface LocalKnopAddReferenceRequest {
+  designatorPath: string;
+  referenceTargetDesignatorPath: string;
+  referenceRole: string;
+}
+
+export interface ExecuteKnopAddReferenceOptions {
+  workspaceRoot: string;
+  request: LocalKnopAddReferenceRequest;
+  operationalLogger?: StructuredLogger;
+  auditLogger?: AuditLogger;
+}
+
+export interface KnopAddReferenceResult {
+  meshBase: string;
+  designatorPath: string;
+  referenceTargetDesignatorPath: string;
+  referenceCatalogIri: string;
+  referenceLinkIri: string;
+  referenceRoleIri: string;
+  referenceTargetIri: string;
+  createdPaths: readonly string[];
+  updatedPaths: readonly string[];
+}
+
+export class KnopAddReferenceRuntimeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "KnopAddReferenceRuntimeError";
+  }
+}
+
+export async function executeKnopAddReference(
+  options: ExecuteKnopAddReferenceOptions,
+): Promise<KnopAddReferenceResult> {
+  const { operationalLogger, auditLogger } = resolveLoggers(options);
+  const workspaceRoot = options.workspaceRoot;
+  const designatorPath = options.request.designatorPath;
+  const referenceTargetDesignatorPath =
+    options.request.referenceTargetDesignatorPath;
+  const referenceRole = options.request.referenceRole;
+  let plan: KnopAddReferencePlan | undefined;
+
+  await operationalLogger.info(
+    "knop.addReference.started",
+    "Starting local knop add-reference",
+    {
+      workspaceRoot,
+      designatorPath,
+      referenceTargetDesignatorPath,
+      referenceRole,
+    },
+  );
+  await auditLogger.record(
+    "knop.addReference.started",
+    "Local knop add-reference started",
+    {
+      workspaceRoot,
+      designatorPath,
+      referenceTargetDesignatorPath,
+      referenceRole,
+    },
+  );
+
+  try {
+    await ensureWorkspaceRootExists(workspaceRoot);
+    const normalizedDesignatorPath = normalizeLocalDesignatorPath(
+      designatorPath,
+      "designatorPath",
+    );
+    const normalizedReferenceTargetDesignatorPath =
+      normalizeLocalDesignatorPath(
+        referenceTargetDesignatorPath,
+        "referenceTargetDesignatorPath",
+      );
+    const meshBase = await loadMeshBase(workspaceRoot);
+    const currentKnopInventoryTurtle = await loadCurrentKnopInventory(
+      workspaceRoot,
+      normalizedDesignatorPath,
+    );
+
+    plan = planKnopAddReference({
+      meshBase,
+      currentKnopInventoryTurtle,
+      designatorPath,
+      referenceTargetDesignatorPath,
+      referenceRole,
+    });
+
+    await assertReferenceTargetExists(
+      workspaceRoot,
+      normalizedReferenceTargetDesignatorPath,
+    );
+    await assertCreateTargetsDoNotExist(workspaceRoot, plan);
+    await writeCreatedFiles(workspaceRoot, plan);
+    await writeUpdatedFiles(workspaceRoot, plan);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await operationalLogger.error(
+      "knop.addReference.failed",
+      "Local knop add-reference failed",
+      {
+        workspaceRoot,
+        designatorPath,
+        referenceTargetDesignatorPath,
+        referenceRole,
+        referenceCatalogIri: plan?.referenceCatalogIri,
+        referenceLinkIri: plan?.referenceLinkIri,
+        error: message,
+      },
+    );
+    await auditLogger.record(
+      "knop.addReference.failed",
+      "Local knop add-reference failed",
+      {
+        workspaceRoot,
+        designatorPath,
+        referenceTargetDesignatorPath,
+        referenceRole,
+        referenceCatalogIri: plan?.referenceCatalogIri,
+        referenceLinkIri: plan?.referenceLinkIri,
+        error: message,
+      },
+    );
+
+    if (
+      error instanceof KnopAddReferenceInputError ||
+      error instanceof KnopAddReferenceRuntimeError
+    ) {
+      throw error;
+    }
+    throw new KnopAddReferenceRuntimeError(message);
+  }
+
+  const result: KnopAddReferenceResult = {
+    meshBase: plan.meshBase,
+    designatorPath: plan.designatorPath,
+    referenceTargetDesignatorPath: plan.referenceTargetDesignatorPath,
+    referenceCatalogIri: plan.referenceCatalogIri,
+    referenceLinkIri: plan.referenceLinkIri,
+    referenceRoleIri: plan.referenceRoleIri,
+    referenceTargetIri: plan.referenceTargetIri,
+    createdPaths: plan.createdFiles.map((file) => file.path),
+    updatedPaths: plan.updatedFiles.map((file) => file.path),
+  };
+
+  await operationalLogger.info(
+    "knop.addReference.succeeded",
+    "Local knop add-reference succeeded",
+    {
+      workspaceRoot,
+      designatorPath: result.designatorPath,
+      referenceTargetDesignatorPath: result.referenceTargetDesignatorPath,
+      referenceCatalogIri: result.referenceCatalogIri,
+      referenceLinkIri: result.referenceLinkIri,
+      referenceRoleIri: result.referenceRoleIri,
+      referenceTargetIri: result.referenceTargetIri,
+      createdPaths: result.createdPaths,
+      updatedPaths: result.updatedPaths,
+    },
+  );
+  await auditLogger.record(
+    "knop.addReference.succeeded",
+    "Local knop add-reference succeeded",
+    {
+      workspaceRoot,
+      designatorPath: result.designatorPath,
+      referenceTargetDesignatorPath: result.referenceTargetDesignatorPath,
+      referenceCatalogIri: result.referenceCatalogIri,
+      referenceLinkIri: result.referenceLinkIri,
+      referenceRoleIri: result.referenceRoleIri,
+      referenceTargetIri: result.referenceTargetIri,
+      createdPaths: result.createdPaths,
+      updatedPaths: result.updatedPaths,
+    },
+  );
+
+  return result;
+}
+
+export function describeKnopAddReferenceResult(
+  result: KnopAddReferenceResult,
+): string {
+  return `Added reference link ${result.referenceLinkIri} targeting ${result.referenceTargetIri}, created ${result.createdPaths.length} reference-catalog artifact, and updated ${result.updatedPaths.length} knop support artifact.`;
+}
+
+function resolveLoggers(
+  options: ExecuteKnopAddReferenceOptions,
+): {
+  operationalLogger: StructuredLogger;
+  auditLogger: AuditLogger;
+} {
+  return resolveRuntimeLoggers(options);
+}
+
+async function ensureWorkspaceRootExists(workspaceRoot: string): Promise<void> {
+  let stat: Deno.FileInfo;
+  try {
+    stat = await Deno.stat(workspaceRoot);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new KnopAddReferenceRuntimeError(
+        `Workspace root does not exist: ${workspaceRoot}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!stat.isDirectory) {
+    throw new KnopAddReferenceRuntimeError(
+      `Workspace root is not a directory: ${workspaceRoot}`,
+    );
+  }
+}
+
+async function loadMeshBase(workspaceRoot: string): Promise<string> {
+  const meshMetadataPath = join(workspaceRoot, "_mesh/_meta/meta.ttl");
+  let meshMetadataTurtle: string;
+
+  try {
+    meshMetadataTurtle = await Deno.readTextFile(meshMetadataPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new KnopAddReferenceRuntimeError(
+        "Workspace does not contain an existing mesh support surface",
+      );
+    }
+    throw error;
+  }
+
+  const meshBaseMatch = meshMetadataTurtle.match(
+    /sflo:meshBase "([^"]+)"\^\^xsd:anyURI/,
+  );
+  if (!meshBaseMatch) {
+    throw new KnopAddReferenceRuntimeError(
+      "Could not resolve meshBase from _mesh/_meta/meta.ttl",
+    );
+  }
+
+  return meshBaseMatch[1]!;
+}
+
+async function loadCurrentKnopInventory(
+  workspaceRoot: string,
+  designatorPath: string,
+): Promise<string> {
+  const knobInventoryPath = join(
+    workspaceRoot,
+    `${designatorPath}/_knop/_inventory/inventory.ttl`,
+  );
+
+  try {
+    return await Deno.readTextFile(knobInventoryPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new KnopAddReferenceRuntimeError(
+        `Workspace does not contain an existing knop support surface for ${designatorPath}`,
+      );
+    }
+    throw error;
+  }
+}
+
+async function assertReferenceTargetExists(
+  workspaceRoot: string,
+  referenceTargetDesignatorPath: string,
+): Promise<void> {
+  const targetKnopInventoryPath = join(
+    workspaceRoot,
+    `${referenceTargetDesignatorPath}/_knop/_inventory/inventory.ttl`,
+  );
+
+  let stat: Deno.FileInfo;
+  try {
+    stat = await Deno.stat(targetKnopInventoryPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new KnopAddReferenceRuntimeError(
+        `Referenced target does not exist in the workspace: ${referenceTargetDesignatorPath}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!stat.isFile) {
+    throw new KnopAddReferenceRuntimeError(
+      `Referenced target inventory is not a file: ${referenceTargetDesignatorPath}`,
+    );
+  }
+}
+
+async function assertCreateTargetsDoNotExist(
+  workspaceRoot: string,
+  plan: KnopAddReferencePlan,
+): Promise<void> {
+  for (const file of plan.createdFiles) {
+    try {
+      await Deno.stat(join(workspaceRoot, file.path));
+      throw new KnopAddReferenceRuntimeError(
+        `knop add-reference target already exists: ${file.path}`,
+      );
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+async function writeCreatedFiles(
+  workspaceRoot: string,
+  plan: KnopAddReferencePlan,
+): Promise<void> {
+  for (const file of plan.createdFiles) {
+    const absolutePath = join(workspaceRoot, file.path);
+    await Deno.mkdir(dirname(absolutePath), { recursive: true });
+    await Deno.writeTextFile(absolutePath, file.contents, { createNew: true });
+  }
+}
+
+async function writeUpdatedFiles(
+  workspaceRoot: string,
+  plan: KnopAddReferencePlan,
+): Promise<void> {
+  for (const file of plan.updatedFiles) {
+    const absolutePath = join(workspaceRoot, file.path);
+    await Deno.mkdir(dirname(absolutePath), { recursive: true });
+    await Deno.writeTextFile(absolutePath, file.contents);
+  }
+}
+
+function normalizeLocalDesignatorPath(
+  designatorPath: string,
+  fieldName: string,
+): string {
+  const trimmed = designatorPath.trim();
+  if (trimmed.length === 0) {
+    throw new KnopAddReferenceRuntimeError(`${fieldName} is required`);
+  }
+  if (trimmed.startsWith("/") || trimmed.endsWith("/")) {
+    throw new KnopAddReferenceRuntimeError(
+      `${fieldName} must not start or end with '/'`,
+    );
+  }
+  if (
+    trimmed.includes("\\") || trimmed.includes("?") || trimmed.includes("#")
+  ) {
+    throw new KnopAddReferenceRuntimeError(
+      `${fieldName} contains unsupported path characters`,
+    );
+  }
+
+  const segments = trimmed.split("/");
+  if (segments.some((segment) => segment.length === 0)) {
+    throw new KnopAddReferenceRuntimeError(
+      `${fieldName} must not contain empty path segments`,
+    );
+  }
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new KnopAddReferenceRuntimeError(
+      `${fieldName} must not contain '.' or '..' path segments`,
+    );
+  }
+  if (segments.some((segment) => reservedDesignatorSegments.has(segment))) {
+    throw new KnopAddReferenceRuntimeError(
+      `${fieldName} must not contain reserved path segments`,
+    );
+  }
+
+  return trimmed;
+}

--- a/src/runtime/knop/add_reference.ts
+++ b/src/runtime/knop/add_reference.ts
@@ -9,6 +9,7 @@ import type { AuditLogger } from "../logging/audit_logger.ts";
 import type { StructuredLogger } from "../logging/logger.ts";
 
 const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
+const safeDesignatorSegmentPattern = /^[A-Za-z0-9._-]+$/;
 
 export interface LocalKnopAddReferenceRequest {
   designatorPath: string;
@@ -40,6 +41,18 @@ export class KnopAddReferenceRuntimeError extends Error {
     super(message);
     this.name = "KnopAddReferenceRuntimeError";
   }
+}
+
+interface StagedFileMutation {
+  absolutePath: string;
+  tempPath: string;
+  backupPath?: string;
+}
+
+interface StagedPlanMutation {
+  createdFiles: StagedFileMutation[];
+  updatedFiles: StagedFileMutation[];
+  createdDirectories: string[];
 }
 
 export async function executeKnopAddReference(
@@ -94,8 +107,8 @@ export async function executeKnopAddReference(
     plan = planKnopAddReference({
       meshBase,
       currentKnopInventoryTurtle,
-      designatorPath,
-      referenceTargetDesignatorPath,
+      designatorPath: normalizedDesignatorPath,
+      referenceTargetDesignatorPath: normalizedReferenceTargetDesignatorPath,
       referenceRole,
     });
 
@@ -104,8 +117,7 @@ export async function executeKnopAddReference(
       normalizedReferenceTargetDesignatorPath,
     );
     await assertCreateTargetsDoNotExist(workspaceRoot, plan);
-    await writeCreatedFiles(workspaceRoot, plan);
-    await writeUpdatedFiles(workspaceRoot, plan);
+    await applyPlanAtomically(workspaceRoot, plan);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await operationalLogger.error(
@@ -156,35 +168,11 @@ export async function executeKnopAddReference(
     updatedPaths: plan.updatedFiles.map((file) => file.path),
   };
 
-  await operationalLogger.info(
-    "knop.addReference.succeeded",
-    "Local knop add-reference succeeded",
-    {
-      workspaceRoot,
-      designatorPath: result.designatorPath,
-      referenceTargetDesignatorPath: result.referenceTargetDesignatorPath,
-      referenceCatalogIri: result.referenceCatalogIri,
-      referenceLinkIri: result.referenceLinkIri,
-      referenceRoleIri: result.referenceRoleIri,
-      referenceTargetIri: result.referenceTargetIri,
-      createdPaths: result.createdPaths,
-      updatedPaths: result.updatedPaths,
-    },
-  );
-  await auditLogger.record(
-    "knop.addReference.succeeded",
-    "Local knop add-reference succeeded",
-    {
-      workspaceRoot,
-      designatorPath: result.designatorPath,
-      referenceTargetDesignatorPath: result.referenceTargetDesignatorPath,
-      referenceCatalogIri: result.referenceCatalogIri,
-      referenceLinkIri: result.referenceLinkIri,
-      referenceRoleIri: result.referenceRoleIri,
-      referenceTargetIri: result.referenceTargetIri,
-      createdPaths: result.createdPaths,
-      updatedPaths: result.updatedPaths,
-    },
+  await logKnopAddReferenceSucceededBestEffort(
+    operationalLogger,
+    auditLogger,
+    workspaceRoot,
+    result,
   );
 
   return result;
@@ -320,28 +308,6 @@ async function assertCreateTargetsDoNotExist(
   }
 }
 
-async function writeCreatedFiles(
-  workspaceRoot: string,
-  plan: KnopAddReferencePlan,
-): Promise<void> {
-  for (const file of plan.createdFiles) {
-    const absolutePath = join(workspaceRoot, file.path);
-    await Deno.mkdir(dirname(absolutePath), { recursive: true });
-    await Deno.writeTextFile(absolutePath, file.contents, { createNew: true });
-  }
-}
-
-async function writeUpdatedFiles(
-  workspaceRoot: string,
-  plan: KnopAddReferencePlan,
-): Promise<void> {
-  for (const file of plan.updatedFiles) {
-    const absolutePath = join(workspaceRoot, file.path);
-    await Deno.mkdir(dirname(absolutePath), { recursive: true });
-    await Deno.writeTextFile(absolutePath, file.contents);
-  }
-}
-
 function normalizeLocalDesignatorPath(
   designatorPath: string,
   fieldName: string,
@@ -379,6 +345,290 @@ function normalizeLocalDesignatorPath(
       `${fieldName} must not contain reserved path segments`,
     );
   }
+  for (const segment of segments) {
+    if (!safeDesignatorSegmentPattern.test(segment)) {
+      throw new KnopAddReferenceRuntimeError(
+        `normalizeDesignatorPath rejected segment "${segment}" in ${fieldName}: toKnopPath only accepts path segments matching [A-Za-z0-9._-]+`,
+      );
+    }
+  }
 
   return trimmed;
+}
+
+async function applyPlanAtomically(
+  workspaceRoot: string,
+  plan: KnopAddReferencePlan,
+): Promise<void> {
+  const stagedPlanMutation = await stagePlanMutation(workspaceRoot, plan);
+
+  try {
+    await commitStagedPlanMutation(stagedPlanMutation);
+  } catch (error) {
+    try {
+      await rollbackStagedPlanMutation(stagedPlanMutation);
+    } catch (rollbackError) {
+      const message = error instanceof Error ? error.message : String(error);
+      const rollbackMessage = rollbackError instanceof Error
+        ? rollbackError.message
+        : String(rollbackError);
+      throw new KnopAddReferenceRuntimeError(
+        `Atomic knop add-reference commit failed: ${message}; rollback also failed: ${rollbackMessage}`,
+      );
+    }
+
+    throw error;
+  }
+
+  await cleanupCommittedStagedPlanMutationBestEffort(stagedPlanMutation);
+}
+
+async function stagePlanMutation(
+  workspaceRoot: string,
+  plan: KnopAddReferencePlan,
+): Promise<StagedPlanMutation> {
+  const stagedPlanMutation: StagedPlanMutation = {
+    createdFiles: [],
+    updatedFiles: [],
+    createdDirectories: [],
+  };
+  const trackedDirectories = new Set<string>();
+
+  try {
+    for (const file of plan.createdFiles) {
+      const absolutePath = join(workspaceRoot, file.path);
+      const directoryPath = dirname(absolutePath);
+      await ensureDirectoryExists(
+        directoryPath,
+        stagedPlanMutation.createdDirectories,
+        trackedDirectories,
+      );
+      stagedPlanMutation.createdFiles.push({
+        absolutePath,
+        tempPath: await writeStagedFile(directoryPath, file.contents),
+      });
+    }
+
+    for (const file of plan.updatedFiles) {
+      const absolutePath = join(workspaceRoot, file.path);
+      const directoryPath = dirname(absolutePath);
+      await ensureDirectoryExists(
+        directoryPath,
+        stagedPlanMutation.createdDirectories,
+        trackedDirectories,
+      );
+      stagedPlanMutation.updatedFiles.push({
+        absolutePath,
+        tempPath: await writeStagedFile(directoryPath, file.contents),
+        backupPath: join(
+          directoryPath,
+          `.weave-backup-${crypto.randomUUID()}.ttl`,
+        ),
+      });
+    }
+  } catch (error) {
+    await rollbackStagedPlanMutation(stagedPlanMutation);
+    throw error;
+  }
+
+  return stagedPlanMutation;
+}
+
+async function ensureDirectoryExists(
+  directoryPath: string,
+  createdDirectories: string[],
+  trackedDirectories: Set<string>,
+): Promise<void> {
+  const missingDirectories: string[] = [];
+  let currentPath = directoryPath;
+
+  while (true) {
+    try {
+      const stat = await Deno.stat(currentPath);
+      if (!stat.isDirectory) {
+        throw new KnopAddReferenceRuntimeError(
+          `Workspace path is not a directory: ${currentPath}`,
+        );
+      }
+      break;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        missingDirectories.push(currentPath);
+        const parentPath = dirname(currentPath);
+        if (parentPath === currentPath) {
+          break;
+        }
+        currentPath = parentPath;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  if (missingDirectories.length === 0) {
+    return;
+  }
+
+  await Deno.mkdir(directoryPath, { recursive: true });
+  for (const createdDirectory of missingDirectories.reverse()) {
+    if (trackedDirectories.has(createdDirectory)) {
+      continue;
+    }
+    trackedDirectories.add(createdDirectory);
+    createdDirectories.push(createdDirectory);
+  }
+}
+
+async function writeStagedFile(
+  directoryPath: string,
+  contents: string,
+): Promise<string> {
+  const tempPath = join(
+    directoryPath,
+    `.weave-staged-${crypto.randomUUID()}.tmp`,
+  );
+  await Deno.writeTextFile(tempPath, contents, { createNew: true });
+  return tempPath;
+}
+
+async function commitStagedPlanMutation(
+  stagedPlanMutation: StagedPlanMutation,
+): Promise<void> {
+  for (const file of stagedPlanMutation.createdFiles) {
+    await Deno.rename(file.tempPath, file.absolutePath);
+  }
+
+  for (const file of stagedPlanMutation.updatedFiles) {
+    await Deno.rename(file.absolutePath, file.backupPath!);
+    await Deno.rename(file.tempPath, file.absolutePath);
+  }
+}
+
+async function rollbackStagedPlanMutation(
+  stagedPlanMutation: StagedPlanMutation,
+): Promise<void> {
+  let firstRollbackError: unknown;
+
+  for (const file of [...stagedPlanMutation.updatedFiles].reverse()) {
+    try {
+      await removePathIfExists(file.tempPath);
+      if (!(await pathExists(file.backupPath!))) {
+        continue;
+      }
+      await removePathIfExists(file.absolutePath);
+      await Deno.rename(file.backupPath!, file.absolutePath);
+    } catch (error) {
+      firstRollbackError ??= error;
+    }
+  }
+
+  for (const file of [...stagedPlanMutation.createdFiles].reverse()) {
+    try {
+      await removePathIfExists(file.tempPath);
+      await removePathIfExists(file.absolutePath);
+    } catch (error) {
+      firstRollbackError ??= error;
+    }
+  }
+
+  await removeEmptyDirectoriesBestEffort(stagedPlanMutation.createdDirectories);
+
+  if (firstRollbackError) {
+    throw firstRollbackError;
+  }
+}
+
+async function cleanupCommittedStagedPlanMutationBestEffort(
+  stagedPlanMutation: StagedPlanMutation,
+): Promise<void> {
+  for (const file of stagedPlanMutation.createdFiles) {
+    await removePathIfExistsBestEffort(file.tempPath);
+  }
+
+  for (const file of stagedPlanMutation.updatedFiles) {
+    await removePathIfExistsBestEffort(file.tempPath);
+    await removePathIfExistsBestEffort(file.backupPath!);
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function removePathIfExists(path: string): Promise<void> {
+  try {
+    await Deno.remove(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function removePathIfExistsBestEffort(path: string): Promise<void> {
+  try {
+    await removePathIfExists(path);
+  } catch {
+    // Best-effort cleanup should never fail the committed operation.
+  }
+}
+
+async function removeEmptyDirectoriesBestEffort(
+  createdDirectories: readonly string[],
+): Promise<void> {
+  for (const directoryPath of [...createdDirectories].reverse()) {
+    try {
+      await Deno.remove(directoryPath);
+    } catch {
+      // Rollback cleanup should not obscure the primary result.
+    }
+  }
+}
+
+async function logKnopAddReferenceSucceededBestEffort(
+  operationalLogger: StructuredLogger,
+  auditLogger: AuditLogger,
+  workspaceRoot: string,
+  result: KnopAddReferenceResult,
+): Promise<void> {
+  const attributes = {
+    workspaceRoot,
+    designatorPath: result.designatorPath,
+    referenceTargetDesignatorPath: result.referenceTargetDesignatorPath,
+    referenceCatalogIri: result.referenceCatalogIri,
+    referenceLinkIri: result.referenceLinkIri,
+    referenceRoleIri: result.referenceRoleIri,
+    referenceTargetIri: result.referenceTargetIri,
+    createdPaths: result.createdPaths,
+    updatedPaths: result.updatedPaths,
+  };
+
+  try {
+    await operationalLogger.info(
+      "knop.addReference.succeeded",
+      "Local knop add-reference succeeded",
+      attributes,
+    );
+  } catch {
+    // Success logging must not turn a committed workspace mutation into a failure.
+  }
+
+  try {
+    await auditLogger.record(
+      "knop.addReference.succeeded",
+      "Local knop add-reference succeeded",
+      attributes,
+    );
+  } catch {
+    // Success logging must not turn a committed workspace mutation into a failure.
+  }
 }

--- a/src/runtime/knop/mod.ts
+++ b/src/runtime/knop/mod.ts
@@ -1,1 +1,2 @@
 export * from "./create.ts";
+export * from "./add_reference.ts";

--- a/tests/e2e/knop_add_reference_cli_test.ts
+++ b/tests/e2e/knop_add_reference_cli_test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { join, relative } from "@std/path";
 import { compareRdfContent } from "../../dependencies/github.com/spectacular-voyage/accord/src/checker/compare_rdf.ts";
 import {
@@ -98,6 +98,55 @@ Deno.test("weave knop add-reference matches the manifest-scoped alice-bio refere
 
   await Deno.stat(join(workspaceRoot, ".weave/logs/operational.jsonl"));
   await Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl"));
+});
+
+Deno.test("weave knop add-reference rejects a whitespace-only positional designatorPath before logging or execution", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-e2e-knop-add-reference-empty-",
+  );
+  await materializeMeshAliceBioBranch(
+    "07-alice-bio-integrated-woven",
+    workspaceRoot,
+  );
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "src/main.ts",
+      "knop",
+      "add-reference",
+      "   ",
+      "--reference-target-designator-path",
+      "alice/bio",
+      "--reference-role",
+      "canonical",
+      "--workspace",
+      workspaceRoot,
+    ],
+    cwd: new URL(".", repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  assertEquals(output.success, false);
+  assert(
+    stderr.includes("knop add-reference requires a positional designatorPath"),
+    stderr,
+  );
+  await assertRejects(
+    () => Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl")),
+    Deno.errors.NotFound,
+  );
+  await assertRejects(
+    () =>
+      Deno.stat(join(workspaceRoot, "alice/_knop/_references/references.ttl")),
+    Deno.errors.NotFound,
+  );
 });
 
 async function listRelativeFiles(

--- a/tests/e2e/knop_add_reference_cli_test.ts
+++ b/tests/e2e/knop_add_reference_cli_test.ts
@@ -1,0 +1,131 @@
+import { assert, assertEquals } from "@std/assert";
+import { join, relative } from "@std/path";
+import { compareRdfContent } from "../../dependencies/github.com/spectacular-voyage/accord/src/checker/compare_rdf.ts";
+import {
+  getManifestFileExpectations,
+  readSingleTransitionCase,
+} from "../support/accord_manifest.ts";
+import {
+  listMeshAliceBioBranchFiles,
+  materializeMeshAliceBioBranch,
+  readMeshAliceBioBranchFile,
+  resolveMeshAliceBioConformanceManifestPath,
+} from "../support/mesh_alice_bio_fixture.ts";
+import { createTestTmpDir } from "../support/test_tmp.ts";
+
+const repoRoot = new URL("../../", import.meta.url);
+
+Deno.test("weave knop add-reference matches the manifest-scoped alice-bio referenced fixture as a black-box CLI run", async () => {
+  const manifestPath = resolveMeshAliceBioConformanceManifestPath(
+    "08-alice-bio-referenced.jsonld",
+  );
+  const transitionCase = await readSingleTransitionCase(manifestPath);
+  assertEquals(transitionCase.operationId, "knop.addReference");
+  assertEquals(transitionCase.fromRef, "07-alice-bio-integrated-woven");
+  assertEquals(transitionCase.toRef, "08-alice-bio-referenced");
+
+  const workspaceRoot = await createTestTmpDir("weave-e2e-knop-add-reference-");
+  await materializeMeshAliceBioBranch(transitionCase.fromRef!, workspaceRoot);
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "src/main.ts",
+      "knop",
+      "add-reference",
+      transitionCase.targetDesignatorPath!,
+      "--reference-target-designator-path",
+      "alice/bio",
+      "--reference-role",
+      "canonical",
+      "--workspace",
+      workspaceRoot,
+    ],
+    cwd: new URL(".", repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  assert(output.success, stderr);
+  assert(stdout.includes("Added reference link"), stdout);
+
+  assertEquals(
+    await listRelativeFiles(workspaceRoot, ".weave/"),
+    await listMeshAliceBioBranchFiles(transitionCase.toRef!),
+  );
+
+  const fileExpectations = getManifestFileExpectations(transitionCase);
+  for (const fileExpectation of fileExpectations) {
+    const path = fileExpectation.path;
+    if (!path) {
+      continue;
+    }
+
+    const actualBytes = await Deno.readFile(join(workspaceRoot, path));
+    const expectedBytes = new TextEncoder().encode(
+      await readMeshAliceBioBranchFile(transitionCase.toRef!, path),
+    );
+    const compareMode = fileExpectation.compareMode ?? "bytes";
+
+    if (compareMode === "rdfCanonical") {
+      assertEquals(
+        await compareRdfContent({
+          left: actualBytes,
+          right: expectedBytes,
+          path,
+        }),
+        true,
+      );
+      continue;
+    }
+
+    if (compareMode === "text") {
+      assertEquals(
+        new TextDecoder().decode(actualBytes),
+        new TextDecoder().decode(expectedBytes),
+      );
+      continue;
+    }
+
+    assertEquals(actualBytes, expectedBytes);
+  }
+
+  await Deno.stat(join(workspaceRoot, ".weave/logs/operational.jsonl"));
+  await Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl"));
+});
+
+async function listRelativeFiles(
+  root: string,
+  excludedPrefix: string,
+): Promise<string[]> {
+  const paths: string[] = [];
+
+  for await (const entry of walkFiles(root)) {
+    const rel = relative(root, entry).replaceAll("\\", "/");
+    if (rel.startsWith(excludedPrefix)) {
+      continue;
+    }
+    paths.push(rel);
+  }
+
+  return paths.sort();
+}
+
+async function* walkFiles(root: string): AsyncGenerator<string> {
+  for await (const entry of Deno.readDir(root)) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory) {
+      yield* walkFiles(path);
+      continue;
+    }
+    if (entry.isFile) {
+      yield path;
+    }
+  }
+}

--- a/tests/integration/knop_add_reference_test.ts
+++ b/tests/integration/knop_add_reference_test.ts
@@ -139,6 +139,60 @@ Deno.test("executeKnopAddReference rejects unsafe designator segments before tou
   );
 });
 
+Deno.test("executeKnopAddReference preserves the original failure when failed-path logging also throws", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-knop-add-reference-failed-logging-",
+  );
+  await materializeMeshAliceBioBranch(
+    "07-alice-bio-integrated-woven",
+    workspaceRoot,
+  );
+  await Deno.mkdir(join(workspaceRoot, "alice/_knop/_references"), {
+    recursive: true,
+  });
+  await Deno.writeTextFile(
+    join(workspaceRoot, "alice/_knop/_references/references.ttl"),
+    "# existing\n",
+  );
+
+  const throwingOperationalLogger = new StructuredLogger([{
+    write(record: { event: string }) {
+      if (record.event === "knop.addReference.failed") {
+        throw new Error("operational failed log failed");
+      }
+    },
+  }], {
+    channel: "operational",
+  });
+  const throwingAuditLogger = new AuditLogger(
+    new StructuredLogger([{
+      write(record: { event: string }) {
+        if (record.event === "knop.addReference.failed") {
+          throw new Error("audit failed log failed");
+        }
+      },
+    }], {
+      channel: "security-audit",
+    }),
+  );
+
+  await assertRejects(
+    () =>
+      executeKnopAddReference({
+        workspaceRoot,
+        request: {
+          designatorPath: "alice",
+          referenceTargetDesignatorPath: "alice/bio",
+          referenceRole: "canonical",
+        },
+        operationalLogger: throwingOperationalLogger,
+        auditLogger: throwingAuditLogger,
+      }),
+    KnopAddReferenceRuntimeError,
+    "already exists",
+  );
+});
+
 Deno.test("executeKnopAddReference treats success logging failures as best-effort after commit", async () => {
   const workspaceRoot = await createTestTmpDir(
     "weave-knop-add-reference-logging-",
@@ -149,7 +203,7 @@ Deno.test("executeKnopAddReference treats success logging failures as best-effor
   );
 
   const throwingOperationalLogger = new StructuredLogger([{
-    async write(record: { event: string }) {
+    write(record: { event: string }) {
       if (record.event === "knop.addReference.succeeded") {
         throw new Error("operational success log failed");
       }
@@ -159,7 +213,7 @@ Deno.test("executeKnopAddReference treats success logging failures as best-effor
   });
   const throwingAuditLogger = new AuditLogger(
     new StructuredLogger([{
-      async write(record: { event: string }) {
+      write(record: { event: string }) {
         if (record.event === "knop.addReference.succeeded") {
           throw new Error("audit success log failed");
         }

--- a/tests/integration/knop_add_reference_test.ts
+++ b/tests/integration/knop_add_reference_test.ts
@@ -1,0 +1,108 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import {
+  executeKnopAddReference,
+  KnopAddReferenceRuntimeError,
+} from "../../src/runtime/knop/add_reference.ts";
+import {
+  materializeMeshAliceBioBranch,
+  readMeshAliceBioBranchFile,
+} from "../support/mesh_alice_bio_fixture.ts";
+import { createTestTmpDir } from "../support/test_tmp.ts";
+
+Deno.test("executeKnopAddReference matches the settled alice-bio referenced fixture", async () => {
+  const workspaceRoot = await createTestTmpDir("weave-knop-add-reference-");
+  await materializeMeshAliceBioBranch(
+    "07-alice-bio-integrated-woven",
+    workspaceRoot,
+  );
+
+  const result = await executeKnopAddReference({
+    workspaceRoot,
+    request: {
+      designatorPath: "alice",
+      referenceTargetDesignatorPath: "alice/bio",
+      referenceRole: "canonical",
+    },
+  });
+
+  assertEquals(
+    result.referenceCatalogIri,
+    "https://semantic-flow.github.io/mesh-alice-bio/alice/_knop/_references",
+  );
+  assertEquals(
+    result.referenceLinkIri,
+    "https://semantic-flow.github.io/mesh-alice-bio/alice/_knop/_references#reference001",
+  );
+  assertEquals(
+    result.referenceRoleIri,
+    "https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Canonical",
+  );
+  assertEquals(result.createdPaths, ["alice/_knop/_references/references.ttl"]);
+  assertEquals(result.updatedPaths, ["alice/_knop/_inventory/inventory.ttl"]);
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_references/references.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "08-alice-bio-referenced",
+      "alice/_knop/_references/references.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_inventory/inventory.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "08-alice-bio-referenced",
+      "alice/_knop/_inventory/inventory.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "_mesh/_inventory/inventory.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "08-alice-bio-referenced",
+      "_mesh/_inventory/inventory.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(join(workspaceRoot, "alice/_knop/_meta/meta.ttl")),
+    await readMeshAliceBioBranchFile(
+      "08-alice-bio-referenced",
+      "alice/_knop/_meta/meta.ttl",
+    ),
+  );
+});
+
+Deno.test("executeKnopAddReference fails closed when the reference catalog working file already exists", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-knop-add-reference-existing-",
+  );
+  await materializeMeshAliceBioBranch(
+    "07-alice-bio-integrated-woven",
+    workspaceRoot,
+  );
+  await Deno.mkdir(join(workspaceRoot, "alice/_knop/_references"), {
+    recursive: true,
+  });
+  await Deno.writeTextFile(
+    join(workspaceRoot, "alice/_knop/_references/references.ttl"),
+    "# existing\n",
+  );
+
+  await assertRejects(
+    () =>
+      executeKnopAddReference({
+        workspaceRoot,
+        request: {
+          designatorPath: "alice",
+          referenceTargetDesignatorPath: "alice/bio",
+          referenceRole: "canonical",
+        },
+      }),
+    KnopAddReferenceRuntimeError,
+    "already exists",
+  );
+});

--- a/tests/integration/knop_add_reference_test.ts
+++ b/tests/integration/knop_add_reference_test.ts
@@ -4,6 +4,8 @@ import {
   executeKnopAddReference,
   KnopAddReferenceRuntimeError,
 } from "../../src/runtime/knop/add_reference.ts";
+import { AuditLogger } from "../../src/runtime/logging/audit_logger.ts";
+import { StructuredLogger } from "../../src/runtime/logging/logger.ts";
 import {
   materializeMeshAliceBioBranch,
   readMeshAliceBioBranchFile,
@@ -104,5 +106,91 @@ Deno.test("executeKnopAddReference fails closed when the reference catalog worki
       }),
     KnopAddReferenceRuntimeError,
     "already exists",
+  );
+});
+
+Deno.test("executeKnopAddReference rejects unsafe designator segments before touching the workspace", async () => {
+  const workspaceRoot = await createTestTmpDir("weave-knop-add-reference-bad-");
+  await materializeMeshAliceBioBranch(
+    "07-alice-bio-integrated-woven",
+    workspaceRoot,
+  );
+
+  await assertRejects(
+    () =>
+      executeKnopAddReference({
+        workspaceRoot,
+        request: {
+          designatorPath: "alice:bio",
+          referenceTargetDesignatorPath: "alice/bio",
+          referenceRole: "canonical",
+        },
+      }),
+    KnopAddReferenceRuntimeError,
+    'normalizeDesignatorPath rejected segment "alice:bio"',
+  );
+
+  await assertRejects(
+    () =>
+      Deno.stat(
+        join(workspaceRoot, "alice:bio/_knop/_references/references.ttl"),
+      ),
+    Deno.errors.NotFound,
+  );
+});
+
+Deno.test("executeKnopAddReference treats success logging failures as best-effort after commit", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-knop-add-reference-logging-",
+  );
+  await materializeMeshAliceBioBranch(
+    "07-alice-bio-integrated-woven",
+    workspaceRoot,
+  );
+
+  const throwingOperationalLogger = new StructuredLogger([{
+    async write(record: { event: string }) {
+      if (record.event === "knop.addReference.succeeded") {
+        throw new Error("operational success log failed");
+      }
+    },
+  }], {
+    channel: "operational",
+  });
+  const throwingAuditLogger = new AuditLogger(
+    new StructuredLogger([{
+      async write(record: { event: string }) {
+        if (record.event === "knop.addReference.succeeded") {
+          throw new Error("audit success log failed");
+        }
+      },
+    }], {
+      channel: "security-audit",
+    }),
+  );
+
+  const result = await executeKnopAddReference({
+    workspaceRoot,
+    request: {
+      designatorPath: "alice",
+      referenceTargetDesignatorPath: "alice/bio",
+      referenceRole: "canonical",
+    },
+    operationalLogger: throwingOperationalLogger,
+    auditLogger: throwingAuditLogger,
+  });
+
+  assertEquals(
+    result.createdPaths,
+    ["alice/_knop/_references/references.ttl"],
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_references/references.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "08-alice-bio-referenced",
+      "alice/_knop/_references/references.ttl",
+    ),
   );
 });


### PR DESCRIPTION
- add core planning and local runtime execution for `knop.addReference`
- wire `weave knop add-reference` into the CLI with explicit target designator and `referenceRole`
- add unit, integration, and black-box CLI tests for the settled `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` fixture
- add `[[wd.spec.2026-04-04-knop-add-reference-behavior]]` for the first carried reference-catalog behavior
- rename the task note to completed and update `wd.todo`, `wd.decision-log`, `wd.codebase-overview`, and related conversation links

@coderabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing weave CLI command to add a reference link between KNOPs; requires an explicit reference role, creates a ReferenceCatalog and a stable ReferenceLink, and updates KNOP inventory.

* **Documentation**
  * Updated overview, decision log, spec notes, tasks, and guidance to describe behavior, acceptance criteria, and planned slices for the new flow.

* **Tests**
  * Added unit, integration, and end-to-end tests exercising CLI and local execution, validation paths, and success/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->