### PR TITLE
feat(weave): carry alice 08 -> 09 reference-catalog weave slice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,4 +23,6 @@
 - Do not rename `wd.task.*` notes to `wd.completed.*` unless the user explicitly asks you to.
   - The human may prefer to do the task-note rename manually after review.
 
+- After any  round of significan code changes, run lint and provide a reasonably-detailed commit message, 
+
 - DON'T BE A PUSHOVER. Humans are usually at-least-partially wrong about things. Effective humans want reasoned push-back.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,6 @@
 - Do not rename `wd.task.*` notes to `wd.completed.*` unless the user explicitly asks you to.
   - The human may prefer to do the task-note rename manually after review.
 
-- After any  round of significan code changes, run lint and provide a reasonably-detailed commit message, 
+- After any round of significant code changes run the linter and provide a reasonably detailed commit message.
 
 - DON'T BE A PUSHOVER. Humans are usually at-least-partially wrong about things. Effective humans want reasoned push-back.

--- a/documentation/notes/wd.codebase-overview.md
+++ b/documentation/notes/wd.codebase-overview.md
@@ -12,7 +12,7 @@ created: 1773673181726
   semantic operations and domain rules
   mesh create, knop create, integrate, version, validate, generate, extract, weave
   request/result types shared by all callers
-  current carried slices: `mesh create` request validation/support-artifact rendering, `knop create` planning over an existing mesh inventory, the first narrow `integrate` planning slice for `05-alice-knop-created-woven` -> `06-alice-bio-integrated`, the first narrow `knop add-reference` planning slice for `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced`, and the first two narrow `weave` planning slices for `04-alice-knop-created` -> `05-alice-knop-created-woven` and `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`
+  current carried slices: `mesh create` request validation/support-artifact rendering, `knop create` planning over an existing mesh inventory, the first narrow `integrate` planning slice for `05-alice-knop-created-woven` -> `06-alice-bio-integrated`, the first narrow `knop add-reference` planning slice for `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced`, and the first three narrow `weave` planning slices for `04-alice-knop-created` -> `05-alice-knop-created-woven`, `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven`
 
 ### runtime
   local workspace execution
@@ -20,7 +20,7 @@ created: 1773673181726
   job execution primitives, but not HTTP
   includes first-pass Deno-native structured operational and audit logging
   persistent config direction is RDF, probably JSON-LD, and should remain queryable via SPARQL
-  current carried slices: local filesystem materialization for `mesh create`, `knop create`, `knop add-reference`, the first local `integrate` pass over an existing workspace payload file, and the first two local `weave` passes over an existing workspace with a shared runtime ResourcePage renderer seam
+  current carried slices: local filesystem materialization for `mesh create`, `knop create`, `knop add-reference`, the first local `integrate` pass over an existing workspace payload file, and the first three local `weave` passes over an existing workspace with a shared runtime ResourcePage renderer seam
   current logging slice: narrow Kato-inspired `LogRecord` / sink / `StructuredLogger` / `AuditLogger` JSONL layer
 
 ### daemon
@@ -36,7 +36,7 @@ created: 1773673181726
   local mode: calls core/runtime directly
   no separate semantic logic
   current carried slices: top-level local `weave`, plus local `weave mesh create`, `weave knop create`, `weave knop add-reference`, and `weave integrate`, all over shared core/runtime
-  current acceptance paths: black-box CLI execution checked against the `02-mesh-created`, `04-alice-knop-created`, `05-alice-knop-created-woven`, `06-alice-bio-integrated`, `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` Accord manifest scopes
+  current acceptance paths: black-box CLI execution checked against the `02-mesh-created`, `04-alice-knop-created`, `05-alice-knop-created-woven`, `06-alice-bio-integrated`, `07-alice-bio-integrated-woven`, `08-alice-bio-referenced`, and `09-alice-bio-referenced-woven` Accord manifest scopes
 
 ### web app
   browser client of daemon
@@ -54,9 +54,10 @@ created: 1773673181726
 - The third carried implementation slice is the local `integrate` path matching the settled Alice Bio `05-alice-knop-created-woven` -> `06-alice-bio-integrated` fixture state.
 - The fourth carried implementation slice is the local `weave` path matching the settled Alice Bio `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven` fixture state.
 - The fifth carried implementation slice is the local `knop add-reference` path matching the settled Alice Bio `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` fixture state.
-- The current carried `weave` slices are the local `04-alice-knop-created` -> `05-alice-knop-created-woven` and `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven` paths, including first-history creation for Knop support artifacts, first payload-artifact history creation, and minimal generated HTML pages rendered through a shared runtime page seam.
+- The sixth carried implementation slice is the local `weave` path matching the settled Alice Bio `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` fixture state.
+- The current carried `weave` slices are the local `04-alice-knop-created` -> `05-alice-knop-created-woven`, `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` paths, including first-history creation for Knop support artifacts, first payload-artifact history creation, first ReferenceCatalog history creation on an already-versioned Knop surface, and minimal generated HTML pages rendered through a shared runtime page seam.
 - `mesh create` now has a manifest-scoped black-box CLI acceptance test and thin framework example payloads.
 - `knop create` now resolves `meshBase` from existing mesh metadata, creates the first Knop support artifacts, and has a manifest-scoped black-box CLI acceptance test.
 - `knop add-reference` now resolves `meshBase` from existing mesh metadata, requires an explicit local `referenceRole`, creates the first Knop-owned `ReferenceCatalog` working file, updates the existing Knop inventory, and has manifest-scoped black-box CLI acceptance coverage for `08-alice-bio-referenced`.
 - `integrate` now resolves a local source path or `file:` URL into a mesh-relative working file path, creates the first payload-Knop support artifacts, updates MeshInventory, and has manifest-scoped black-box CLI acceptance coverage together with thin framework examples.
-- `weave` now runs as the top-level local CLI action, versions the first Alice Knop support artifacts and the first Alice Bio payload history surface, advances MeshInventory where the public current surface changed, and has manifest-scoped black-box CLI acceptance coverage through `07`.
+- `weave` now runs as the top-level local CLI action, versions the first Alice Knop support artifacts, the first Alice Bio payload history surface, and the first Alice ReferenceCatalog history surface, advances MeshInventory only where the public current surface changed, and has manifest-scoped black-box CLI acceptance coverage through `09`.

--- a/documentation/notes/wd.codebase-overview.md
+++ b/documentation/notes/wd.codebase-overview.md
@@ -10,9 +10,9 @@ created: 1773673181726
 
 ### core
   semantic operations and domain rules
-  mesh create, knop create, integrate, version, validate, generate, extract, weave
+  mesh create, knop create, integrate, payload update, version, validate, generate, extract, weave
   request/result types shared by all callers
-  current carried slices: `mesh create` request validation/support-artifact rendering, `knop create` planning over an existing mesh inventory, the first narrow `integrate` planning slice for `05-alice-knop-created-woven` -> `06-alice-bio-integrated`, the first narrow `knop add-reference` planning slice for `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced`, and the first three narrow `weave` planning slices for `04-alice-knop-created` -> `05-alice-knop-created-woven`, `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven`
+  current carried slices: `mesh create` request validation/support-artifact rendering, `knop create` planning over an existing mesh inventory, the first narrow `integrate` planning slice for `05-alice-knop-created-woven` -> `06-alice-bio-integrated`, the first narrow `knop add-reference` planning slice for `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced`, the first narrow `payload.update` planning slice for `09-alice-bio-referenced-woven` -> `10-alice-bio-updated`, and the first three narrow `weave` planning slices for `04-alice-knop-created` -> `05-alice-knop-created-woven`, `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven`
 
 ### runtime
   local workspace execution
@@ -20,7 +20,7 @@ created: 1773673181726
   job execution primitives, but not HTTP
   includes first-pass Deno-native structured operational and audit logging
   persistent config direction is RDF, probably JSON-LD, and should remain queryable via SPARQL
-  current carried slices: local filesystem materialization for `mesh create`, `knop create`, `knop add-reference`, the first local `integrate` pass over an existing workspace payload file, and the first three local `weave` passes over an existing workspace with a shared runtime ResourcePage renderer seam
+  current carried slices: local filesystem materialization for `mesh create`, `knop create`, `knop add-reference`, the first local `integrate` pass over an existing workspace payload file, the first local `payload.update` pass over an already woven payload artifact, and the first three local `weave` passes over an existing workspace with a shared runtime ResourcePage renderer seam
   current logging slice: narrow Kato-inspired `LogRecord` / sink / `StructuredLogger` / `AuditLogger` JSONL layer
 
 ### daemon
@@ -35,8 +35,8 @@ created: 1773673181726
   remote mode: talks to daemon over HTTP
   local mode: calls core/runtime directly
   no separate semantic logic
-  current carried slices: top-level local `weave`, plus local `weave mesh create`, `weave knop create`, `weave knop add-reference`, and `weave integrate`, all over shared core/runtime
-  current acceptance paths: black-box CLI execution checked against the `02-mesh-created`, `04-alice-knop-created`, `05-alice-knop-created-woven`, `06-alice-bio-integrated`, `07-alice-bio-integrated-woven`, `08-alice-bio-referenced`, and `09-alice-bio-referenced-woven` Accord manifest scopes
+  current carried slices: top-level local `weave`, plus local `weave mesh create`, `weave knop create`, `weave knop add-reference`, `weave integrate`, and `weave payload update`, all over shared core/runtime
+  current acceptance paths: black-box CLI execution checked against the `02-mesh-created`, `04-alice-knop-created`, `05-alice-knop-created-woven`, `06-alice-bio-integrated`, `07-alice-bio-integrated-woven`, `08-alice-bio-referenced`, `09-alice-bio-referenced-woven`, and `10-alice-bio-updated` Accord manifest scopes
 
 ### web app
   browser client of daemon
@@ -55,9 +55,11 @@ created: 1773673181726
 - The fourth carried implementation slice is the local `weave` path matching the settled Alice Bio `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven` fixture state.
 - The fifth carried implementation slice is the local `knop add-reference` path matching the settled Alice Bio `07-alice-bio-integrated-woven` -> `08-alice-bio-referenced` fixture state.
 - The sixth carried implementation slice is the local `weave` path matching the settled Alice Bio `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` fixture state.
+- The seventh carried implementation slice is the local `payload.update` path matching the settled Alice Bio `09-alice-bio-referenced-woven` -> `10-alice-bio-updated` fixture state.
 - The current carried `weave` slices are the local `04-alice-knop-created` -> `05-alice-knop-created-woven`, `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` paths, including first-history creation for Knop support artifacts, first payload-artifact history creation, first ReferenceCatalog history creation on an already-versioned Knop surface, and minimal generated HTML pages rendered through a shared runtime page seam.
 - `mesh create` now has a manifest-scoped black-box CLI acceptance test and thin framework example payloads.
 - `knop create` now resolves `meshBase` from existing mesh metadata, creates the first Knop support artifacts, and has a manifest-scoped black-box CLI acceptance test.
 - `knop add-reference` now resolves `meshBase` from existing mesh metadata, requires an explicit local `referenceRole`, creates the first Knop-owned `ReferenceCatalog` working file, updates the existing Knop inventory, and has manifest-scoped black-box CLI acceptance coverage for `08-alice-bio-referenced`.
 - `integrate` now resolves a local source path or `file:` URL into a mesh-relative working file path, creates the first payload-Knop support artifacts, updates MeshInventory, and has manifest-scoped black-box CLI acceptance coverage together with thin framework examples.
+- `payload.update` now resolves the existing working payload file from an already woven payload surface, stages replacement bytes from a local path or `file:` URL without changing the semantic mesh path, updates only `alice-bio.ttl` for the carried `10` slice, and has manifest-scoped black-box CLI acceptance coverage together with thin framework examples.
 - `weave` now runs as the top-level local CLI action, versions the first Alice Knop support artifacts, the first Alice Bio payload history surface, and the first Alice ReferenceCatalog history surface, advances MeshInventory only where the public current surface changed, and has manifest-scoped black-box CLI acceptance coverage through `09`.

--- a/documentation/notes/wd.conv.2026.2026-04-05_0842-implement-wd-task-2026-2026-04-04-1553-weave-alice-bio-re-codex.md
+++ b/documentation/notes/wd.conv.2026.2026-04-05_0842-implement-wd-task-2026-2026-04-04-1553-weave-alice-bio-re-codex.md
@@ -1,0 +1,638 @@
+---
+id: implement-wdtask20262026-weylcx
+title: 'Implement [[wd.task.2026.2026-04-04_1553-weave-alice-bio-re…'
+desc: ''
+created: 1775403749671
+updated: 1775403749671
+participants: [djradon, codex.gpt-5.4]
+---
+
+# User_2026-04-04_2220_24
+
+Implement [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]].
+
+Context:
+- `08-alice-bio-referenced` is implemented and passing.
+- next carried slice is `08 -> 09`
+- reuse [[wd.spec.2026-04-03-weave-behavior]]
+- start with failing integration and black-box CLI tests against `09-alice-bio-referenced-woven`
+- extend the shared weave/page seam for current and historical ReferenceCatalog pages
+- keep `_mesh/_inventory/inventory.ttl` unchanged
+- do not rename the task note to completed unless explicitly asked
+
+# gpt-5.4_2026-04-04_2220_30
+
+I’m implementing `[[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]]` by first reading the repo guidance and the task/spec notes, then I’ll add failing integration and CLI coverage for `09-alice-bio-referenced-woven` before touching the implementation seam.
+
+I’ve confirmed the worktree is clean. Next I’m pulling the task note, spec, and repo guidance into context so the test additions and seam changes stay aligned with the existing slice conventions.
+
+The task note is explicit: lead with failing `09` integration and black-box CLI coverage, then extend the shared page-generation seam rather than forking a new path. I’m locating the existing `08` implementation, the `09` fixture ladder, and the test harnesses that already carry earlier slices.
+
+I’ve got the fixture and ontology constraints in hand. Next I’m reading the current weave planner/runtime and the existing `05`/`07` tests so I can add `09` in the same harness instead of inventing new test plumbing.
+
+I’ve confirmed the current weave code only recognizes two slices: first Knop weave and first payload weave. There is no `ReferenceCatalog` path yet, so I’m inspecting the settled `08 -> 09` fixture diff now to mirror the exact artifact/history and page outputs instead of guessing them.
+
+The `09` fixture is narrower than a generalized catalog renderer: one new inventory state, first catalog history, and a special current catalog page with a single current link anchor. I’m pulling the exact TTL blocks now so the new planner preserves the byte-for-byte working/snapshot invariants instead of merely graph-equivalent output.
+
+The `09` slice exposes a real constraint in the runtime loader, not just missing render code: it currently drops any Knop whose inventory already has history, which was fine for `07` but makes `alice` in `08` invisible. I’m checking whether there’s any reusable history/version helper already in the codebase before I patch that path directly.
+
+I have enough context to start the TDD pass. I’m editing the existing weave integration and black-box CLI suites to add `08 -> 09` cases first, with assertions focused on the catalog history, advanced Knop inventory, and unchanged mesh inventory.
+
+The `09` cases are in. I’m running just the affected weave integration and CLI suites now to capture the current failure mode before I touch planner/runtime code.
+
+The first run only exposed Deno permission gaps in the test harness, not product behavior. I’m rerunning with the permissions these fixture-driven tests actually need so we get the real `09` failure signal.
+
+The failure is the expected one: `08` produces zero weave candidates because the runtime still filters out any Knop inventory that already has explicit history. The implementation work from here is:
+
+- extend candidate discovery so a Knop with an already-versioned inventory can still be weaveable when its attached `ReferenceCatalog` is still only a working file
+- add a narrow `firstReferenceCatalogWeave` planner path that:
+  - snapshots `alice/_knop/_references/references.ttl` into `_history001/_s0001`
+  - advances `alice/_knop/_inventory` from `_s0001` to `_s0002`
+  - leaves `_mesh/_inventory/inventory.ttl` untouched
+- extend the shared page seam with a `ReferenceCatalog` current-page model plus the first catalog-history pages so `alice/_knop/_references/index.html` renders the `#reference001` anchor from the current catalog
+- backfill unit coverage around the new planner/page model, then rerun the targeted weave suites and the focused core/runtime tests that exercise the new seam
+
+The integration and CLI regressions are enough to drive the runtime change, but I also want narrow planner/page assertions so we don’t end up debugging this only at the filesystem level. I’m adding one core weave test and one page-render test for the new `ReferenceCatalog` seam before implementing it.
+
+I’m patching the core planner first: new candidate/page model types, a third weave-slice classification for a first `ReferenceCatalog` weave, and relaxed candidate prechecks so an already-versioned Knop inventory can still participate when the catalog itself is not yet woven.
+
+The core path is in place. I’m wiring the runtime loader to discover a Knop as weaveable when its `ReferenceCatalog` is still only a working file, while continuing to ignore already-fully-woven Knops like `alice/bio`.
+
+The new planner/runtime path is wired. I’m running the focused unit, integration, and black-box weave suites together now to catch type mismatches and exact-fixture drift before I touch any notes.
+
+The code and focused tests are green. I’m doing the close-out docs pass required by the repo guidance now: task-note checkbox updates, then the minimal spec/overview/decision-log changes so the carried `09` slice is reflected accurately without renaming the task note.
+
+I’m updating only the minimum docs the repo explicitly asks to keep in sync: the task note checklist, the weave behavior note’s carried-slice status, the codebase overview, and a new decision-log entry for the `08 -> 09` weave boundary.
+
+I’ve finished the note updates. I’m formatting only the changed TypeScript files, not the markdown notes, so I don’t accidentally reflow the Dendron docs against the repo guidance.
+
+The code is formatted. I’m doing the final verification pass now: the focused weave unit/integration/CLI suites again, plus a `git diff --check` sanity pass for whitespace and patch hygiene.
+
+The verification pass is clean. I’m checking the final diff summary now so the close-out can stay high-signal and not miss any touched file category.
+
+Implemented the `08-alice-bio-referenced -> 09-alice-bio-referenced-woven` slice. The core change is in [weave.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave.ts#L12): there is now a third narrow local weave path for a first `ReferenceCatalog` weave, and [weave.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/weave.ts#L195) now discovers a Knop as weaveable when its inventory already has history but its attached catalog does not. The shared page seam in [pages.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/pages.ts#L15) now renders current `ReferenceCatalog` pages, so `alice/_knop/_references/index.html` gets the current `#reference001` anchor while the planner creates the first catalog history and advances only `alice/_knop/_inventory` to `_s0002`; `_mesh/_inventory/inventory.ttl` stays unchanged.
+
+Added coverage in [weave_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave_test.ts#L132), [pages_test.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/pages_test.ts#L38), [weave_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/weave_test.ts#L118), and [weave_cli_test.ts](/home/djradon/hub/semantic-flow/weave/tests/e2e/weave_cli_test.ts#L32), and updated the task/spec/overview/decision notes without renaming the task note.
+
+Verified with `deno test --allow-env --allow-read --allow-write --allow-run src/core/weave/weave_test.ts src/runtime/weave/pages_test.ts tests/integration/weave_test.ts tests/e2e/weave_cli_test.ts` and `git diff --check`. I did not run the full repo test suite.
+
+# User_2026-04-04_2233_12
+
+commit message
+
+# gpt-5.4_2026-04-04_2233_24
+
+```text
+feat(weave): carry alice 08 -> 09 reference-catalog weave slice
+
+- add unit, integration, and black-box CLI coverage for the settled 09-alice-bio-referenced-woven transition
+- extend local weave planning and runtime candidate loading to support first ReferenceCatalog weaving on an already-versioned Knop surface
+- version alice/_knop/_references into _history001/_s0001 and advance alice/_knop/_inventory to _s0002 while keeping _mesh/_inventory unchanged
+- extend the shared page-rendering seam to cover current and historical ReferenceCatalog pages, including the current #reference001 anchor
+- update the weave behavior note, codebase overview, decision log, and task note checklist for the carried 08 -> 09 slice
+```
+
+# User_2026-04-04_2233_26
+
+Any learnings you can apply to [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]] ?
+
+# gpt-5.4_2026-04-04_2233_38
+
+I’m checking the `10-alice-bio-updated` task note against what the `09` implementation exposed in practice, then I’ll patch the note only where the new constraints are real and actionable.
+
+There are a few concrete lessons from `09` worth baking into the `10` note, not just hand-waving: treat the already-versioned payload surface as normal input, explicitly freeze the newly generated catalog pages, and move the manifest-backed CLI test earlier in the TDD loop. I’m patching those into the task note now.
+
+Yes. I applied a few concrete `09` learnings directly to [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]]:
+
+- clarified that `payload.update` must treat the already-versioned `alice/bio` payload surface as normal input, not as an unsupported “already woven” shape
+- made the frozen `09` outputs explicit non-targets, including `alice/_knop/_references/index.html`, `alice/_knop/_references/_history001/...`, and `alice/bio/index.html`
+- pulled the manifest-backed black-box CLI test earlier in the TDD loop, alongside failing integration coverage, since that caught the real `09` shape issue quickly
+- tightened the note so the operation is clearly “update only the working payload bytes, do not route through page generation”
+
+I didn’t run tests because this was a task-note-only edit.
+
+# User_2026-04-04_2236_09
+
+can we just proceed, same chat, same branch?
+
+# gpt-5.4_2026-04-04_2236_17
+
+Yes. Same chat and same branch are fine.
+
+This next slice is a direct continuation of the one we just carried, so there’s no technical need to split context. The only real reason to stop would be if you want a separate commit/review boundary first. Otherwise I can continue straight into [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]] on the current branch.
+
+# User_2026-04-04_2237_27
+
+continue
+
+# gpt-5.4_2026-04-04_2237_40
+
+I’m continuing directly into `[[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]]`. First step is to inspect the settled `09 -> 10` fixture, the existing `integrate`/`knop add-reference` patterns, and whether a `payload.update` spec or code stub already exists before I add failing tests.
+
+The fixture is cleaner than `09`: only `alice-bio.ttl` changes, and the manifest already nails the machine-facing name as `payload.update`. I’m inspecting the current `integrate` and `knop add-reference` implementations now so I can reuse their request/runtime split and choose a CLI spelling that is consistent instead of inventing a one-off.
+
+There’s no existing `payload.update` implementation or spec stub, but the framework already fixes the operationId. I’m looking for any existing naming precedent for the CLI surface now; if there isn’t one, I’ll keep it conservative and mirror `integrate`’s “source first, designator explicit” pattern rather than guessing something broader.
+
+I don’t see any prior CLI precedent for `payload.update`, so I’m going with the least surprising shape: `weave payload update <path-or-file-url> [designatorPath]`, with `--designator-path` as the explicit form, matching the first carried `integrate` CLI rather than forcing a new source-last exception. Before code, I’m drafting the dedicated `wd.spec.*` note the task calls for, then I’ll lock behavior with failing integration and e2e tests.
+
+The structure is flat and consistent enough to add `src/core/payload/update.ts` and `src/runtime/payload/update.ts` cleanly. I’m drafting the behavior spec note now, then I’ll add failing `10` integration and CLI tests plus the new payload modules in the same shape as `integrate`.
+
+I found the main design tension before writing code: if `payload.update` uses the same “source must already be inside the workspace” rule as `integrate`, the operation either becomes a no-op on the target file or requires extra staging files that would violate the `10` fixture. I’m checking the prior conversation notes for that exact point rather than papering over it.
+
+I found the strongest concrete constraint for `payload.update`: unlike `integrate`, the replacement source should not be forced to live inside the workspace, because the operation’s whole point is to overwrite an already-known working file without leaving extra staging artifacts behind. I’m encoding that explicitly in the new behavior spec and then implementing the runtime to stage bytes from a local path or `file:` URL into the existing working payload file atomically.
+
+I’m writing the dedicated `payload.update` behavior note now. The key design call in it is explicit: local runtime may stage replacement bytes from a local path or `file:` URL outside the workspace, because the target working file is already part of the mesh and only that file should change in `10`.
+
+The spec note is in. I’m adding the first failing `10` tests now, and I’m deliberately using an external replacement source in both harnesses so the runtime contract is forced to preserve the “only `alice-bio.ttl` changes” invariant.
+
+The first `10` tests are in. I’m running only those new suites now to capture the failure mode before implementation; at this point a missing module or command is the expected result.
+
+I’m editing the code now. The implementation is split the same way as `integrate`: `core` plans from `designatorPath + resolved working file path + replacement bytes`, and `runtime` handles local source resolution plus the atomic overwrite of the existing working payload file.
+
+The core planner is in. I’m patching the runtime and CLI now: resolve the existing working payload from `alice/bio/_knop/_inventory/inventory.ttl`, stage replacement bytes from a local source, and expose the command as `weave payload update ...`.
+
+The command wiring is in. I’m running the new payload-update unit, integration, and CLI suites now; if anything still fails, it should be on the actual behavior, not missing files or command routes.
+
+The first payload-update path is already green, which means the remaining decision is documentation scope, not implementation. I’m checking the framework contract next: if `payload.update` is still absent from `JobKind` and the Alice Bio API examples, I’m going to add the same thin public-example treatment we gave `integrate` instead of leaving the new carried operation undocumented.
+
+The framework side does need one real update: `payload.update` still isn’t in the public `JobKind` enum, so the carried operation would exist in code and conformance but not in the thin API contract. I’m patching the minimal framework pieces now: enum plus one request and one succeeded-job example, nothing broader.
+
+The new local slice is green, so I’m doing the minimum framework follow-through now: add `payload.update` to the thin job contract and add one request and one succeeded-job example so the public example set doesn’t lag behind the carried operation.
+
+The implementation is done. I’m on the close-out doc/accounting pass now: mark the task note progress, add the carried `payload.update` slice to the codebase overview, and log the design decision that this local runtime stages replacement bytes into an already-known working payload file.
+
+Continuing into the `09 -> 10` payload slice. I’m checking the current worktree and the task/overview/decision notes now, then I’ll patch the remaining docs, run targeted verification, and close it out on this branch.
+
+The implementation is already in place; I’m wiring the remaining notes around the actual behavior now. After that I’ll run `deno fmt` on the touched TypeScript files, rerun the payload-focused suites, and check the diff for whitespace issues.
+
+I have the note deltas scoped now. I’m updating the task checklist to reflect the implemented payload slice, then tightening the overview and decision log so they describe the actual `09 -> 10` boundary and the source-staging choice.
+
+The repo notes are patched. I’m checking whether the framework/example changes landed in the nested `semantic-flow-framework` checkout as expected before I run formatting and the focused payload suites.
+
+Formatting is clean. I also confirmed the thin API/example changes are sitting in the nested `semantic-flow-framework` checkout, so I’m verifying both repos now: payload-focused Deno tests in `weave`, plus whitespace checks in `weave` and the framework checkout.
+
+The broader integration and e2e suite is running now, including the existing `integrate`, `knop`, and `weave` paths. That matters here because the CLI parser and shared exports changed, not just the new payload entry point.
+
+The verification run came back clean: 27 tests passed across the full integration and e2e surface, and both repos are whitespace-clean. I’m pulling exact file locations now so the close-out is precise and concise.
+
+I’ve got the main repo locations. I’m grabbing the exact framework file locations too so I can call out that those API/example changes are in the nested checkout, not this repo’s git history.
+
+The core work is complete. I’m getting a quick diff summary for both checkouts so the close-out reflects scope accurately and calls out the separate framework worktree.
+
+Implemented the `09-alice-bio-referenced-woven -> 10-alice-bio-updated` slice on this branch. The core plan is in [update.ts](/home/djradon/hub/semantic-flow/weave/src/core/payload/update.ts#L5), the local runtime path is in [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts#L48) and [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts#L253), and the CLI surface is in [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts#L132) and [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts#L412). This path updates only the existing working payload file for `alice/bio`, accepts a local path or `file:` source for staging, validates Turtle before commit, and leaves inventories, history, and generated pages unchanged.
+
+Coverage and notes are in [payload_update_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/payload_update_test.ts#L10), [payload_update_cli_test.ts](/home/djradon/hub/semantic-flow/weave/tests/e2e/payload_update_cli_test.ts#L18), [[wd.spec.2026-04-04-payload-update-behavior#L21]], [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload#L124]], [[wd.codebase-overview#L13]], and [[wd.decision-log#L180]]. Thin contract/example updates are also sitting in the nested framework checkout at [semantic-flow-api-spec.yaml](/home/djradon/hub/semantic-flow/weave/dependencies/github.com/semantic-flow/semantic-flow-framework/semantic-flow-api-spec.yaml#L246), [[sf.api.examples#L26]], [payload-update-job-request.jsonld](/home/djradon/hub/semantic-flow/weave/dependencies/github.com/semantic-flow/semantic-flow-framework/examples/alice-bio/api/payload-update-job-request.jsonld#L1), and [payload-update-job-succeeded.jsonld](/home/djradon/hub/semantic-flow/weave/dependencies/github.com/semantic-flow/semantic-flow-framework/examples/alice-bio/api/payload-update-job-succeeded.jsonld#L1).
+
+Verified with `deno test --allow-env --allow-read --allow-write --allow-run src/core/payload/update_test.ts tests/integration tests/e2e` (`27 passed`) and `git diff --check` in both `weave` and the nested `semantic-flow-framework` checkout. I did not run any framework-specific test suite.
+
+# User_2026-04-04_2247_31
+
+commit mesg
+
+# gpt-5.4_2026-04-04_2247_35
+
+```text
+feat(payload): carry alice 09 -> 10 payload update slice
+
+- add the first narrow payload.update core/runtime path for an already woven payload artifact
+- expose the local CLI as `weave payload update <source> [designatorPath]`
+- replace the existing working payload file in place while leaving inventories, histories, and pages unchanged
+- allow runtime-local staging from a local path or file URL without polluting the shared semantic contract with host-path semantics
+- add unit, integration, and manifest-scoped black-box CLI coverage for 10-alice-bio-updated
+- add a dedicated payload.update behavior note and thin semantic-flow-framework request/job examples
+```
+
+# User_2026-04-04_2251_16
+
+From the previous slice, from coderabbit:
+
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@src/core/weave/weave.ts`:
+- Around line 394-449: The planFirstReferenceCatalogWeave currently hardcodes
+"/_references/.../references.ttl" instead of using
+referenceCatalogArtifact.workingFilePath, so update
+planFirstReferenceCatalogWeave to preserve
+referenceCatalogArtifact.workingFilePath: compute
+referenceCatalogWorkingFilePath from referenceCatalogArtifact.workingFilePath
+and use it when building referenceCatalogPath and the createdFiles history
+snapshot path and when calling
+renderFirstReferenceCatalogWovenKnopInventoryTurtle (or extend that function to
+accept the working file path so it can render hasWorkingLocatedFile and history
+manifestation paths correctly). Also either adjust
+assertCurrentKnopInventoryShapeForFirstReferenceCatalogWeave to reject
+unsupported workingFilePath values or ensure the new code supports
+non-"references.ttl" names so the inventory and created files point at the
+actual working file path.
+
+In `@src/runtime/weave/pages.ts`:
+- Around line 51-53: Dynamic values interpolated into the HTML
+(page.currentLinks -> currentLinks string, specifically link.fragment,
+link.referenceRoleLabel, and link.referenceTargetPath) are not escaped, allowing
+markup breakage or XSS; fix by HTML-escaping all interpolated values before
+building the string (introduce or reuse an escapeHtml utility and apply it to
+link.fragment for the id and display, and to link.referenceRoleLabel and
+link.referenceTargetPath for the text/code content), and apply the same escaping
+to the other similar block referenced at lines 64-66 so all dynamic HTML
+fragments are safely encoded.
+
+---
+
+Outside diff comments:
+In `@src/runtime/weave/weave.ts`:
+- Around line 230-250: The code eagerly calls loadPayloadWorkingArtifact and
+loadReferenceCatalogWorkingArtifact before checking eligibility, causing
+failures for already-settled or non-requested knops; update
+loadWeaveableKnopCandidates so you first build a minimal candidate containing
+designatorPath, currentKnopMetadataTurtle and currentKnopInventoryTurtle, call
+isWeaveableKnopCandidate(candidate) and only if it returns true then call
+loadPayloadWorkingArtifact(...) and loadReferenceCatalogWorkingArtifact(...) to
+attach payloadArtifact and referenceCatalogArtifact before pushing the
+candidate.
+
+---
+
+Nitpick comments:
+In `@src/runtime/weave/pages_test.ts`:
+- Around line 36-74: Add a new Deno.test in pages_test.ts that calls
+renderResourcePage (same pattern as the existing "renderResourcePage renders
+current ReferenceCatalog pages with fragment anchors" test) but uses a
+currentLinks entry whose fragment, referenceRoleLabel, and referenceTargetPath
+contain special HTML characters (e.g., &, <, >, "). Assert the produced HTML
+contains the properly escaped entities (e.g., &amp;, &lt;, &gt;, &quot;) in the
+rendered list item and id attribute where appropriate to lock in escaping
+behavior for renderResourcePage.
+
+In `@src/runtime/weave/weave.ts`:
+- Around line 368-401: The predicate in isWeaveableKnopCandidate duplicates the
+slice/marker detection and precedence logic found in classifyWeaveSlice; extract
+the shared detection logic into a single exported utility (e.g.,
+isWeaveableSlice or hasWeaveMarkers) that accepts the same inputs used here
+(candidate.currentKnopInventoryTurtle and candidate.designatorPath or
+equivalent), then replace the body of isWeaveableKnopCandidate and the logic
+inside classifyWeaveSlice to call that new shared function; ensure the new
+utility returns the same boolean semantics (check referenceCatalogRelationship,
+payloadRelationship, and knopInventoryHasHistory) and still uses
+referenceCatalogArtifact/payloadArtifact presence checks via the candidate
+inputs.
+
+# gpt-5.4_2026-04-04_2251_22
+
+I’m checking each CodeRabbit comment against the current `weave` implementation first, then I’ll patch only the ones that still hold and rerun the targeted weave/page tests.
+
+I’ve confirmed at least two of the comments are real on current code: the ReferenceCatalog weave path still hardcodes `references.ttl`, and the page renderer still interpolates unescaped dynamic HTML. I’m checking the runtime candidate-loading complaint and the duplicated slice-detection logic next before I touch code.
+
+The ReferenceCatalog hardcoding is broader than just one path literal: the inventory renderer also bakes in `references.ttl` and the `references-ttl` manifestation directory. I’m tracing the existing payload helper patterns now so I can fix that generically instead of papering over one call site.
+
+The runtime candidate-loading comment still looks valid: the loader resolves working artifacts for every discovered Knop before request filtering or eligibility classification, so an unrelated settled Knop can still fail the whole weave. I’m looking for the smallest test seam to prove that without bloating the slice.
+
+I’ve confirmed three substantive issues and one maintainability fix worth taking now. I’m patching `core` to preserve ReferenceCatalog working file names, patching the page renderer to escape dynamic HTML, and tightening runtime candidate discovery so unrelated or settled Knops don’t block a weave request.
+
+I’m adding two integration checks here rather than one: one locks in the “ignore settled broken Knops” behavior, and the other locks in request scoping so a broken non-requested candidate can’t poison a targeted weave.
+
+The core/runtime/test edits are in. I’m doing a quick static pass over the new call sites now for signature mismatches before I format and run the weave-focused suites.
+
+The weave suite is running. `git diff --check` tripped on an unrelated preexisting trailing-space hunk in [[AGENTS]]; I’m leaving that alone unless you want it cleaned, since it isn’t part of this fix set.
+
+The failing weave tests narrowed this down cleanly: the new ReferenceCatalog helper is right, but I rooted the manifestation segment at the catalog path instead of the historical-state path. I’m correcting that and rerunning the same focused suite.
+
+The weave-specific suite is green now. I’m doing a scoped whitespace check on just the files touched for this follow-up, because the repo still has an unrelated trailing-space change in `AGENTS.md`.
+
+All five CodeRabbit comments held on the current code, and I fixed them.
+
+The ReferenceCatalog weave path now preserves the actual working file path instead of hardcoding `references.ttl`, including the history snapshot path, inventory rendering, and manifestation page path in [weave.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave.ts#L407). I also extracted shared slice detection into `detectPendingWeaveSlice` in [weave.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave.ts#L196), then used it in runtime candidate discovery so settled or non-requested Knops are skipped before any working-artifact load can fail in [weave.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/weave.ts#L57) and [weave.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/weave.ts#L197).
+
+The ReferenceCatalog page renderer now HTML-escapes dynamic content in [pages.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/pages.ts#L15). I added lock-in coverage for the non-default ReferenceCatalog working file path in [weave_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave_test.ts#L319), for HTML escaping in [pages_test.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/pages_test.ts#L76), and for ignoring broken settled and non-requested candidates in [weave_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/weave_test.ts#L210).
+
+Verified with `deno test --allow-env --allow-read --allow-write --allow-run src/core/weave/weave_test.ts src/runtime/weave/pages_test.ts tests/integration/weave_test.ts tests/e2e/weave_cli_test.ts` (`17 passed`) and a scoped `git diff --check` over the touched files. A full `git diff --check` still reports an unrelated trailing-space change in [[AGENTS]], which I left alone.
+
+# User_2026-04-04_2257_06
+
+fix lint error
+
+# gpt-5.4_2026-04-04_2257_15
+
+I’m reproducing the current lint failure first so I fix the real issue rather than guessing from the earlier whitespace check. After that I’ll patch the minimal file set and rerun lint.
+
+The current lint failure is not `AGENTS.md`; it’s a real TypeScript lint violation in [update_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/payload/update_test.ts) where a test callback is marked `async` without awaiting anything. I’m removing only that unnecessary `async`, then I’ll rerun lint.
+
+Fixed the lint error in [update_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/payload/update_test.ts#L32) by removing an unnecessary `async` from a synchronous test callback.
+
+Verified with `deno task lint`, which now passes. The trailing whitespace in [[AGENTS]] is still unrelated to Deno lint.
+
+# User_2026-04-04_2259_21
+
+what about these? 
+
+Verify each finding against the current code and only fix it if needed.
+
+Inline comments:
+In `@src/core/payload/update_test.ts`:
+- Line 32: The Deno.test declaration named "planPayloadUpdate rejects an
+inventory that does not resolve the woven payload artifact" currently declares
+its callback as async but contains no await (triggers require-await); remove the
+unnecessary async modifier from the test callback so the function is a plain
+synchronous function, keeping the test body unchanged and rerunning lint/tests
+to confirm the require-await error is resolved.
+
+In `@src/runtime/payload/update.ts`:
+- Around line 170-174: The message returned by describePayloadUpdateResult
+should remove the redundant "replacing" vs "updating" phrasing and correctly
+pluralize "file"/"files" based on updatedPaths.length; update the function
+(describePayloadUpdateResult) to build a single clear sentence using
+result.payloadArtifactIri and result.workingFilePath, e.g. "Updated payload
+<iri> by replacing working file <path> (updated N path(s))." but implement
+proper plural logic using result.updatedPaths.length to select "file" vs "files"
+and/or "path" vs "paths" so the grammar is correct.
+
+---
+
+Nitpick comments:
+In `@src/cli/run.ts`:
+- Around line 412-440: Extract the duplicated logic in
+resolvePayloadUpdateDesignatorPath and resolveIntegrateDesignatorPath into a
+single helper (e.g., resolveDesignatorPath(options: { designatorPath?: string },
+designatorPathArg?: string): string) and replace both implementations to call
+this helper; ensure the helper preserves current behavior and throws
+PayloadUpdateInputError (or a shared error type) with the same messages used by
+resolvePayloadUpdateDesignatorPath and resolveIntegrateDesignatorPath so callers
+see identical validation and error text, and update references to the original
+functions to use the new helper internally.
+
+In `@src/core/payload/update.ts`:
+- Around line 1-3: The duplicated constant reservedDesignatorSegments (used in
+update.ts and another runtime update.ts) should be extracted into a single
+exported constant in a shared module (e.g., create and export
+RESERVED_DESIGNATOR_SEGMENTS from a new/shared constants file) and both
+update.ts files should import that exported symbol instead of defining their own
+Set; update the references to use the shared RESERVED_DESIGNATOR_SEGMENTS (or
+the chosen exported name) so the set is maintained in one place while preserving
+existing dependency boundaries.
+- Around line 166-187: The current assertCurrentPayloadArtifactShape uses
+brittle string matching (currentKnopInventoryTurtle.includes on
+requiredFragments) which can fail for equivalent RDF with different
+whitespace/order/prefixes; replace the string-based checks in
+assertCurrentPayloadArtifactShape with a semantic RDF check by parsing
+currentKnopInventoryTurtle using an RDF parser (e.g., N3.Parser), convert
+triples/quads into a set you can query, and then verify the expected
+triples/properties (the knop resource a sflo:Knop, sflo:hasPayloadArtifact
+linking to the designatorPath, the designatorPath typed as
+sflo:PayloadArtifact/sflo:DigitalArtifact/sflo:RdfDocument,
+sflo:hasWorkingLocatedFile linking to workingFilePath, and
+sflo:currentArtifactHistory pointing at designatorPath/_history001) using triple
+membership tests against the parsed graph; keep the same PayloadUpdateInputError
+behavior when any required triple is missing and continue to reference the same
+function name and variables (currentKnopInventoryTurtle, designatorPath,
+workingFilePath, requiredFragments) to locate where to implement the
+parser-based checks.
+
+In `@src/runtime/payload/update.ts`:
+- Around line 433-450: applyPayloadUpdateAtomically currently assumes exactly
+one file by using plan.updatedFiles[0] without checks; add a defensive check at
+the start of applyPayloadUpdateAtomically to validate plan.updatedFiles.length
+=== 1 (or handle multiple files), and if the assertion fails throw a clear Error
+(or iterate and process each file consistently), so that the subsequent creation
+of stagedPayloadUpdate (absolutePath, tempPath, backupPath) is only done when a
+valid single-file invariant holds or is adapted to multi-file behavior.
+- Around line 396-413: The function assertUpdatedTargetsExist currently uses
+synchronous Deno.statSync; change it to an async function (export or function
+signature: async function assertUpdatedTargetsExist(...): Promise<void>) and
+replace Deno.statSync(absolutePath) with await Deno.stat(absolutePath) inside a
+try/catch, preserving the same NotFound handling (if (error instanceof
+Deno.errors.NotFound) throw new PayloadUpdateRuntimeError(...); else rethrow).
+Finally update every call site (the caller that invoked
+assertUpdatedTargetsExist) to await the function so it returns a Promise and the
+control flow remains correct.
+
+# gpt-5.4_2026-04-04_2259_26
+
+I’m checking each of those follow-up comments against the current payload code now. If a comment still holds, I’ll patch it; if not, I’ll call out why it’s already satisfied or not worth taking in this slice.
+
+I’ve checked the payload comments against current code. One is already done, one is a real user-facing wording bug, and the rest are low-risk cleanups except the RDF-shape check, which I’m only taking if it stays within the current narrow “settled woven payload shape” boundary.
+
+I’m taking the small cleanups and the wording fix. For the parser-based core check, I’m doing one quick sanity check on how `n3` resolves relative IRIs so I don’t overfit the implementation to one serialization shape.
+
+I’ve confirmed the `async` test comment is already resolved. I’m patching the remaining valid ones now: better payload CLI/result wording, shared designator-segment constant, async target checks plus the single-file guard, the shared CLI helper, and a parser-backed core shape check with a unit test that proves it handles equivalent RDF ordering.
+
+# User_2026-04-04_2301_32
+
+we do have a future task related to rdf, [[wd.task.2026.2026-04-04_0952-rdf-parsing]] if that helps.
+
+# gpt-5.4_2026-04-04_2301_39
+
+That helps. I’m reading the RDF parsing task note now before I touch the parser-backed payload check, because that’s the one comment most likely to overlap future refactoring rather than fix a present defect.
+
+The RDF task note is useful here: it argues against turning this into broad parser cleanup, but it does not block a localized semantic check in `payload.update` itself. I’m keeping that change narrowly scoped to the touched function and test, and I’m not expanding into the broader runtime RDF-read debt called out in the task note.
+
+One patch chunk missed current line offsets in `runtime/payload/update.ts`. I’m re-reading the exact sections and applying that file in a narrower patch so I don’t clobber unrelated edits.
+
+The payload patches are in. I’m formatting the touched files and running payload-focused tests plus lint next so we can separate real follow-up fixes from speculative cleanup.
+
+Lint is clean. The payload suite is still running, including the CLI path, so I’m waiting on that before I call any of these comments resolved.
+
+The payload suite surfaced one real type-check issue from the new parser-backed helper: `quad` needs an explicit type annotation. I’m fixing that and rerunning the same payload-focused test set.
+
+The payload path is green. Because I changed the shared CLI designator-path resolver, I’m running the integrate CLI acceptance too, then I’ll do a scoped whitespace check and summarize which review comments actually held.
+
+Using [[wd.task.2026.2026-04-04_0952-rdf-parsing]] as a boundary was useful. I treated the broad RDF-parser migration as future work, but still took the localized `payload.update` parser fix because that file was already under review and the change stayed narrow.
+
+Status of the comments:
+- The `async` callback in [update_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/payload/update_test.ts) was already fixed before this pass.
+- The awkward `describePayloadUpdateResult` wording was valid and is fixed in [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts).
+- The duplicated CLI designator-path logic was valid and is now shared in [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts).
+- The duplicated reserved designator set between the two payload files was valid and is now shared via [designator_segments.ts](/home/djradon/hub/semantic-flow/weave/src/core/designator_segments.ts).
+- The brittle string-based payload shape check was valid enough to fix locally, and [update.ts](/home/djradon/hub/semantic-flow/weave/src/core/payload/update.ts) now uses parsed RDF quad membership instead of `includes`, with a semantic-equivalence test added in [update_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/payload/update_test.ts).
+- The single-file assumption in `applyPayloadUpdateAtomically` was valid and now has an explicit guard in [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts).
+- The sync `Deno.statSync` target check was valid and is now async in [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts).
+
+I did not broaden the reserved-segment cleanup to the other duplicated modules yet; that would be a separate cleanup pass.
+
+Verified with:
+- `deno task lint`
+- `deno test --allow-env --allow-read --allow-write --allow-run src/core/payload/update_test.ts src/runtime/payload/update_test.ts tests/integration/payload_update_test.ts tests/e2e/payload_update_cli_test.ts`
+- `deno test --allow-env --allow-read --allow-write --allow-run tests/e2e/integrate_cli_test.ts`
+- scoped `git diff --check` over the touched files
+
+# User_2026-04-05_0814_49
+
+commit mesg
+
+# gpt-5.4_2026-04-05_0815_03
+
+```text
+fix(payload): tighten local payload update validation and CLI seams
+
+- improve payload update result wording with correct singular/plural grammar
+- share CLI designator-path resolution between integrate and payload update
+- move payload reserved designator segments into a shared core constant
+- replace payload.update woven-shape string matching with parser-backed quad checks
+- make payload target existence checks async and guard the single-file atomic update invariant
+- add unit coverage for semantic-equivalent payload inventory parsing and result message grammar
+```
+
+# User_2026-04-05_0817_07
+
+OK, ready for [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]] ? New chat or continue in this one?
+
+# gpt-5.4_2026-04-05_0817_17
+
+Yes. Same chat is fine.
+
+This payload task is already implemented on the current branch, and the follow-up review fixes are in as well, so continuing here keeps the best context. A new chat would only help if you want a cleaner transcript or a fresh review boundary; it is not technically necessary.
+
+# User_2026-04-05_0817_55
+
+codecov: 73.60% of diff hit (target 79.10%) -- any valuable coverage we could add?
+
+# gpt-5.4_2026-04-05_0818_06
+
+I’m checking the current diff and the touched tests first, then I’ll identify which changed branches are still uncovered and whether there’s a worthwhile small test to add rather than padding coverage.
+
+The worktree is clean, so I’m looking at the branch diff rather than uncommitted files. Next I’m finding the merge base and the changed files that Codecov is likely scoring.
+
+There are a couple of genuinely useful gaps left, not just Codecov padding. I’m checking the existing CLI/error-test patterns so I can add the highest-signal ones instead of inventing a new test style.
+
+There are three high-signal additions left that look worth doing: one `file:` source-path integration test, one “invalid Turtle leaves the working file untouched” integration test, and a CLI validation test for the shared designator-path helper. I’m adding those rather than chasing internal guards that the public API can’t realistically hit.
+
+I’m adding one more CLI check for the “missing designator path” branch too. That’s still user-facing behavior in the shared resolver, and it’s cheap coverage with real value.
+
+The added tests are all public-behavior tests, not internals. I’m formatting them and running the payload-focused suites plus lint now.
+
+Lint is still clean. The payload test bundle is running now; that includes the new CLI validation cases and the `file:` URL / invalid-RDF runtime paths.
+
+Yes. I added coverage that looks worth keeping, not just padding.
+
+The new tests are in [payload_update_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/payload_update_test.ts) and [payload_update_cli_test.ts](/home/djradon/hub/semantic-flow/weave/tests/e2e/payload_update_cli_test.ts). They cover:
+- `file:` URL payload sources, which the runtime explicitly supports in [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts)
+- invalid Turtle replacement input, with an assertion that the working payload file is left unchanged
+- CLI rejection for conflicting designator paths
+- CLI rejection when the designator path is missing, and confirmation that logging/execution never starts
+
+I verified with `deno task lint` and the payload-focused test bundle; all passed. I have not recomputed Codecov locally, but these should hit real uncovered branches in [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts) and [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts).
+
+If the PR is still short after that, the next worthwhile test would be one `integrate` CLI validation case for the shared designator-path helper in [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts). After that, most remaining uncovered lines are defensive invariants with much lower ROI.
+
+# User_2026-04-05_0845_37
+
+Here's some more coderabbit comments. Implement those you see as valid and worthwhile:
+
+In `@src/core/weave/weave.ts`:
+- Around line 517-536: The function
+assertCurrentMeshInventoryShapeForFirstReferenceCatalogWeave currently hardcodes
+two designator paths ("<alice/_knop>" and "<alice/bio/_knop>") which couples the
+validation to the 08-alice-bio fixture; update this function to either (A)
+accept the expected knop designators as parameters (e.g., pass an array of
+required designator prefixes into
+assertCurrentMeshInventoryShapeForFirstReferenceCatalogWeave) and check for
+those parameterized fragments instead of literal "<alice/_knop>" and
+"<alice/bio/_knop>", or (B) remove the two specific knop fragments from
+requiredFragments and replace them with a more general check (e.g., assert
+presence of any "a sflo:Knop" triple or a regex like /<[^>]+> a sflo:Knop/
+against currentMeshInventoryTurtle) so the precondition is not tied to the alice
+fixture; update callers accordingly to provide expected designators when needed.
+
+In `@src/runtime/payload/update.ts`:
+- Around line 292-311: resolveSourcePath currently sends every source string
+through tryParseUrl which misclassifies Windows paths and colon-containing
+filenames as URLs; change the logic to only treat inputs that explicitly start
+with "file:" as URLs (parse them with fromFileUrl/new URL), detect and reject
+obvious remote schemes of the form "<scheme>://" by throwing the same
+PayloadUpdateRuntimeError for non-file protocols, and otherwise treat the input
+as a filesystem path (using isAbsolute/resolve with workspaceRoot). Update or
+remove tryParseUrl usage accordingly so resolveSourcePath no longer parses
+generic strings through URL constructor.
+
+---
+
+Nitpick comments:
+In `@src/core/weave/weave.ts`:
+- Around line 137-141: The switch over classifyWeaveSlice results (handling
+firstKnopWeave, firstPayloadWeave, firstReferenceCatalogWeave) is treated as
+exhaustive but TypeScript may still consider an undefined return path; make the
+control flow explicit by either changing classifyWeaveSlice to throw on
+unsupported slices or adding a default branch to the switch that throws the
+WeaveInputError; locate the switch that consumes classifyWeaveSlice and either
+update classifyWeaveSlice to throw for unsupported candidates or add an explicit
+default case that throws the existing WeaveInputError (the throw new
+WeaveInputError(...) statement) so there is no unreachable/implicit code path.
+
+In `@src/runtime/weave/weave.ts`:
+- Around line 238-274: You are calling detectPendingWeaveSlice twice for each
+candidate; compute the slice once (as you already do into variable slice) and
+thread it through instead of re-parsing inside isWeaveableKnopCandidate. Update
+isWeaveableKnopCandidate to accept the precomputed slice (e.g., add a parameter
+like candidateSlice) or create a new helper (e.g.,
+isWeaveableKnopCandidateWithSlice) and adjust callers here so you use the
+existing slice to decide whether to load payload/reference via
+loadPayloadWorkingArtifact/loadReferenceCatalogWorkingArtifact and to validate
+the candidate before pushing to candidates.
+
+# gpt-5.4_2026-04-05_0845_45
+
+I’m checking those three areas directly first: the reference-catalog mesh inventory assertion, the payload source-path resolver, and the repeated slice detection in weave runtime. Then I’ll patch only the ones that still hold and rerun the focused suites.
+
+# gpt-5.4_2026-04-05_0847_01
+
+I’ve confirmed three worthwhile changes: generalize the reference-catalog mesh assertion off the hardcoded Alice paths, stop parsing arbitrary payload sources as URLs, and stop re-detecting the same weave slice in runtime candidate loading. I’m patching those now and adding one payload source-path test plus one non-Alice weave test to lock them in.
+
+# gpt-5.4_2026-04-05_0847_22
+
+The payload source-path patch left a duplicated tail from the old implementation. I’m cleaning that up before touching anything else.
+
+# gpt-5.4_2026-04-05_0848_22
+
+The edits are in. I’m formatting the touched files and running the focused weave and payload suites now so we can see whether any of these comments exposed real regressions or just cleanup.
+
+# gpt-5.4_2026-04-05_0848_25
+
+Lint found one leftover helper from the old payload source-path implementation. I’m deleting that dead function and rerunning lint while the test suite finishes.
+
+# gpt-5.4_2026-04-05_0848_38
+
+Lint is clean again. The combined weave/payload suite is still running; I’m waiting for that before I summarize which comments landed.
+
+# gpt-5.4_2026-04-05_0848_43
+
+The generalized mesh-inventory assertion exposed a small ordering bug in `planFirstReferenceCatalogWeave`: I passed `designatorPath` before it was declared. I’m fixing that now and rerunning the same focused suite.
+
+# gpt-5.4_2026-04-05_0849_09
+
+The focused weave and payload suites are green now. I’m doing a final scoped whitespace check and grabbing the touched file list so the close-out is precise.
+
+# gpt-5.4_2026-04-05_0849_25
+
+I took four of the comments.
+
+Applied:
+- Generalized the reference-catalog mesh precondition so it no longer hardcodes `alice` and `alice/bio`; [weave.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave.ts#L414) now checks the current candidate’s Knop path instead, and [weave_test.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave_test.ts#L368) locks that in with a non-Alice case.
+- Fixed payload source resolution in [update.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/payload/update.ts#L292) so only explicit `file:` inputs are parsed as URLs, remote `scheme://` sources are rejected, and colon-containing filenames stay filesystem paths. Coverage is in [payload_update_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/payload_update_test.ts#L105) and [payload_update_test.ts](/home/djradon/hub/semantic-flow/weave/tests/integration/payload_update_test.ts#L138).
+- Added the explicit `default` branch in the `classifyWeaveSlice` consumer switch in [weave.ts](/home/djradon/hub/semantic-flow/weave/src/core/weave/weave.ts#L117).
+- Stopped recomputing `detectPendingWeaveSlice` in runtime weave candidate loading; [weave.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/weave.ts#L243) now computes it once and threads it into [weave.ts](/home/djradon/hub/semantic-flow/weave/src/runtime/weave/weave.ts#L392).
+
+I skipped the rest because there wasn’t anything else in that set worth changing beyond those fixes.
+
+Verified with:
+- `deno task lint`
+- `deno test --allow-env --allow-read --allow-write --allow-run src/core/weave/weave_test.ts tests/integration/weave_test.ts tests/e2e/weave_cli_test.ts src/core/payload/update_test.ts src/runtime/payload/update_test.ts tests/integration/payload_update_test.ts tests/e2e/payload_update_cli_test.ts`
+- scoped `git diff --check`
+
+Unrelated worktree items still present:
+- modified [[AGENTS]]
+- untracked [[wd.conv.2026.2026-04-05_0842-implement-wd-task-2026-2026-04-04-1553-weave-alice-bio-re-codex]]
+
+# User_2026-04-05_0849_58
+
+commit mesg
+
+# gpt-5.4_2026-04-05_0850_06
+
+```text
+fix(weave): generalize reference-catalog checks and tighten source loading
+
+- remove alice-specific mesh-inventory assumptions from the first reference-catalog weave precondition
+- reuse the detected weave slice during runtime candidate loading instead of recomputing it
+- treat only explicit file: inputs as URL sources for payload update and reject remote schemes
+- keep colon-containing payload source filenames on the filesystem-path path
+- add focused weave and payload coverage for non-alice reference-catalog weaving and payload source resolution edge cases
+```

--- a/documentation/notes/wd.conv.2026.2026-04-05_0842-implement-wd-task-2026-2026-04-04-1553-weave-alice-bio-re-codex.md
+++ b/documentation/notes/wd.conv.2026.2026-04-05_0842-implement-wd-task-2026-2026-04-04-1553-weave-alice-bio-re-codex.md
@@ -636,3 +636,44 @@ fix(weave): generalize reference-catalog checks and tighten source loading
 - keep colon-containing payload source filenames on the filesystem-path path
 - add focused weave and payload coverage for non-alice reference-catalog weaving and payload source resolution edge cases
 ```
+
+# User_2026-04-05_0852_19
+
+codecov is still  77.34% of diff hit (target 79.10%). Maybe add the "integrate cli validation case"?
+
+# gpt-5.4_2026-04-05_0852_31
+
+Yes. That’s the next highest-value coverage add: small, public-behavior tests on `integrate` that exercise the shared designator-path helper through the integrate-specific error path, not through `payload update`.
+
+I’m adding focused `integrate` CLI rejection tests for conflicting and missing designator paths, then I’ll rerun that e2e file plus lint.
+
+# gpt-5.4_2026-04-05_0852_48
+
+I have the exact uncovered integrate-specific branches. I’m adding two e2e tests now: one for conflicting positional vs option designator paths, and one for the missing-designator-path case. Both will assert that logging and execution never start.
+
+# gpt-5.4_2026-04-05_0853_04
+
+The integrate CLI tests are in. I’m formatting that file and running just the integrate e2e suite plus lint so we get a quick signal on whether this is enough to move diff coverage.
+
+# gpt-5.4_2026-04-05_0853_08
+
+Lint is clean. The integrate CLI file is still running, and that will tell us whether the no-logging/no-execution assumptions hold on the actual CLI path.
+
+# gpt-5.4_2026-04-05_0853_12
+
+The integrate validation cases passed cleanly. I’m doing a scoped whitespace check and grabbing the exact file reference for the close-out.
+
+# gpt-5.4_2026-04-05_0853_17
+
+Yes. I added the integrate CLI validation cases in [integrate_cli_test.ts](/home/djradon/hub/semantic-flow/weave/tests/e2e/integrate_cli_test.ts#L105):
+
+- conflicting positional vs `--designator-path`
+- missing designator path entirely
+
+Both assert the integrate-specific error text, plus that `.weave/logs` is not created and the integrate target surface is still absent. That’s the right branch to hit for the shared resolver in [run.ts](/home/djradon/hub/semantic-flow/weave/src/cli/run.ts), because payload already covered the shared helper but not the `IntegrateInputError` path.
+
+Verified with:
+- `deno test --allow-env --allow-read --allow-write --allow-run tests/e2e/integrate_cli_test.ts`
+- `deno task lint`
+
+I can’t tell you the new Codecov percentage from local tooling here, but this is the most plausible remaining high-value diff-coverage add for the current branch.

--- a/documentation/notes/wd.decision-log.md
+++ b/documentation/notes/wd.decision-log.md
@@ -175,3 +175,11 @@ created: 1773630801215
 - Why:
   - It proves the first `ReferenceCatalog` history and the first support-artifact weave on an already-versioned Knop surface without widening the mesh inventory beyond the public current surface.
   - The settled `09` fixture only requires one current-link anchor and no retired-link recovery yet, so the shared page seam should grow minimally rather than fork into a separate renderer path.
+
+### 2026-04-04: First Local payload.update Slice Targets Alice 09 -> 10
+
+- Decision: Treat the settled Alice Bio `09-alice-bio-referenced-woven` -> `10-alice-bio-updated` transition as the first carried local `payload.update` implementation slice, expose the human-facing CLI as `weave payload update <source> [designatorPath]` with `--designator-path` as the explicit option form, and keep shared `core` planning centered on the existing woven payload artifact and its mesh-relative working file rather than on host filesystem paths.
+- References: [[wd.task.2026.2026-04-04_2019-update-alice-bio-payload]], [[wd.spec.2026-04-04-payload-update-behavior]]
+- Why:
+  - The settled `10` fixture proves a real semantic payload change while also proving that histories, inventories, and generated pages stay frozen in this non-woven step.
+  - Letting the local runtime stage replacement bytes from a local path or `file:` URL, including one outside the workspace, preserves the one-file `alice-bio.ttl` result without polluting the semantic contract with host-path semantics or temporary mesh artifacts.

--- a/documentation/notes/wd.decision-log.md
+++ b/documentation/notes/wd.decision-log.md
@@ -167,3 +167,11 @@ created: 1773630801215
 - Why:
   - The settled `08` fixture explicitly proves a canonical Alice -> Alice Bio link rather than an omission-default role policy.
   - The later Bob extraction path is the first natural carried `Supplemental` case, so a silent local default would have blurred two different fixture-backed behaviors.
+
+### 2026-04-04: Third Local weave Slice Targets Alice 08 -> 09
+
+- Decision: Treat the settled Alice Bio `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` transition as the next carried local `weave` implementation slice, keep the existing thin `designatorPaths` request surface, version the Knop-owned `ReferenceCatalog`, advance `alice/_knop/_inventory` to `_s0002`, leave `_mesh/_inventory/inventory.ttl` unchanged, and extend the shared runtime page-rendering seam with current and historical `ReferenceCatalog` pages.
+- References: [[wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven]], [[wd.spec.2026-04-03-weave-behavior]]
+- Why:
+  - It proves the first `ReferenceCatalog` history and the first support-artifact weave on an already-versioned Knop surface without widening the mesh inventory beyond the public current surface.
+  - The settled `09` fixture only requires one current-link anchor and no retired-link recovery yet, so the shared page seam should grow minimally rather than fork into a separate renderer path.

--- a/documentation/notes/wd.spec.2026-04-03-weave-behavior.md
+++ b/documentation/notes/wd.spec.2026-04-03-weave-behavior.md
@@ -22,7 +22,7 @@ The rules below are the best current synthesis of:
 - the corresponding Accord conformance manifests
 - the current Semantic Flow ontology direction
 
-The carried local implementation of this behavior currently includes the settled Alice Bio `04-alice-knop-created` -> `05-alice-knop-created-woven` and `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven` slices.
+The carried local implementation of this behavior currently includes the settled Alice Bio `04-alice-knop-created` -> `05-alice-knop-created-woven`, `06-alice-bio-integrated` -> `07-alice-bio-integrated-woven`, and `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` slices.
 
 If future fixture work contradicts this note, the contradiction should be treated as a real design issue and resolved explicitly rather than silently drifting.
 
@@ -131,7 +131,7 @@ That includes:
 - state pages such as `.../_s0001/index.html`
 - manifestation pages such as `.../inventory-ttl/index.html`
 
-For the current carried local `05` and `07` slices, keep the generated HTML aligned with the settled fixture pages even when those pages remain intentionally minimal. Richer identifier wording, state listings, and navigable current pages are proven more fully in later fixture states and should not be retroactively imposed on the earlier acceptance targets.
+For the current carried local `05`, `07`, and `09` slices, keep the generated HTML aligned with the settled fixture pages even when those pages remain intentionally minimal. Richer identifier wording, state listings, and navigable current pages are proven more fully in later fixture states and should not be retroactively imposed on the earlier acceptance targets.
 
 ## What Weave Does Not Do
 
@@ -272,6 +272,8 @@ The main weave-behavior consequences are:
 - `ReferenceLink` identities are stable fragment IRIs rooted at the catalog resource
 - the current catalog page is the dereference target for both current and retired links
 - current catalog page generation must therefore consult both the current working catalog and catalog history
+
+For the current carried local `09` slice, the settled fixture proves only the first current-link case: one current `#reference001` anchor rendered on the current catalog page together with the first catalog-history pages. Richer retired-link recovery remains a later extension of the same page-generation seam rather than completed carried behavior.
 
 That history-aware dereferenceability requirement is unusual enough that it should remain explicit in future implementations.
 

--- a/documentation/notes/wd.spec.2026-04-04-payload-update-behavior.md
+++ b/documentation/notes/wd.spec.2026-04-04-payload-update-behavior.md
@@ -1,0 +1,72 @@
+---
+id: s2q3n6p4c8v1k7m5d9r0wya
+title: 2026 04 04 Payload Update Behavior
+desc: ''
+updated: 1775359260000
+created: 1775359260000
+---
+
+## Purpose
+
+This note captures the current expected behavior of the first `payload.update` slice for Weave.
+
+It is an implementation-facing behavior spec for the first local or in-process path, not a final public API contract.
+
+## Status
+
+This is the current next carried slice after the completed local `08-alice-bio-referenced` -> `09-alice-bio-referenced-woven` `weave` implementation.
+
+The first acceptance target is the settled `mesh-alice-bio` transition from `09-alice-bio-referenced-woven` to `10-alice-bio-updated`.
+
+## Inputs
+
+- `designatorPath` is required.
+- the first local CLI surface should be `weave payload update <source> [designatorPath]`, with `--designator-path` as the explicit option form
+- the target workspace must already contain `_mesh/_meta/meta.ttl` and the woven payload surface for the targeted payload artifact
+- the target `designatorPath` must already resolve to an existing integrated payload artifact with a current `hasWorkingLocatedFile`
+- `meshBase` and the existing working payload file path should be resolved from the workspace rather than repeated on the CLI
+- shared `core` planning should operate on the target `designatorPath`, the already-known working payload file path, and the replacement payload bytes rather than on a host filesystem path
+- the first local runtime slice may stage replacement bytes from an existing local path or `file:` URL outside the workspace, because the replacement source is runtime-local staging rather than a new mesh working file
+
+## What Payload Update Does
+
+`payload.update` replaces the working bytes of an already managed payload artifact without weaving that change yet.
+
+In the current first slice, that means:
+
+- resolving the existing working payload file for `D` from the current payload artifact surface
+- replacing the bytes of that working file in place
+- leaving current inventories, historical payload snapshots, and generated pages unchanged
+- validating that the resulting working payload Turtle parses cleanly before commit
+
+## What Payload Update Does Not Do
+
+In this first slice, `payload.update` does not:
+
+- create a new payload historical state
+- update `_mesh/_inventory/inventory.ttl` or any Knop inventory
+- regenerate `alice/bio/index.html`, `alice/_knop/_references/index.html`, or any other ResourcePage
+- create `bob/_knop` or perform extraction
+- introduce a generic RDF diff, patch, or merge language
+- change the existing working payload file placement
+- run the later `11` weave responsibilities
+
+## Invariants
+
+- in the settled `09` -> `10` fixture, `alice-bio.ttl` is the only changed workspace file
+- `alice/bio/_history001/_s0001/alice-bio-ttl/alice-bio.ttl` remains unchanged until the later woven step
+- `_mesh/_inventory/inventory.ttl` remains unchanged
+- `alice/_knop/_inventory/inventory.ttl` remains unchanged
+- `alice/_knop/_references/references.ttl` and `alice/_knop/_references/index.html` remain unchanged
+- `alice/bio/_knop/_inventory/inventory.ttl` remains unchanged
+- runtime-local `.weave/logs` output is not part of the semantic mesh surface
+
+## Acceptance Reference
+
+The first behavior-level comparison target is:
+
+- fixture repo: `dependencies/github.com/semantic-flow/mesh-alice-bio`
+- from ref: `09-alice-bio-referenced-woven`
+- to ref: `10-alice-bio-updated`
+- manifest: `dependencies/github.com/semantic-flow/semantic-flow-framework/examples/alice-bio/conformance/10-alice-bio-updated.jsonld`
+- local CLI execution should match that manifest-scoped result

--- a/documentation/notes/wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven.md
+++ b/documentation/notes/wd.task.2026.2026-04-04_1553-weave-alice-bio-referenced-woven.md
@@ -132,9 +132,9 @@ That means the task should prove the first history-aware catalog page shape with
 
 - [x] Confirm that [[wd.spec.2026-04-03-weave-behavior]] is sufficient as the current behavior spec for the `09` slice.
 - [x] Confirm that the existing thin local `weave` request/result shape stays narrow for this slice and does not require a new artifact-target model.
-- [ ] Add failing unit and integration tests for the `09` reference-catalog-weave behavior.
-- [ ] Extend the existing shared runtime page-rendering seam to cover current and historical `ReferenceCatalog` pages without introducing a separate renderer path.
-- [ ] Implement the first-history `alice/_knop/_references` weave path and keep the working `references.ttl` file byte-identical to the latest historical snapshot after weave.
-- [ ] Implement `alice/_knop/_inventory` advancement to `_s0002` while keeping `_mesh/_inventory/inventory.ttl` unchanged.
-- [ ] Add a black-box CLI acceptance test scoped by the settled `09-alice-bio-referenced-woven` Accord manifest.
-- [ ] Update relevant overview/spec/framework notes as the slice settles.
+- [x] Add failing unit and integration tests for the `09` reference-catalog-weave behavior.
+- [x] Extend the existing shared runtime page-rendering seam to cover current and historical `ReferenceCatalog` pages without introducing a separate renderer path.
+- [x] Implement the first-history `alice/_knop/_references` weave path and keep the working `references.ttl` file byte-identical to the latest historical snapshot after weave.
+- [x] Implement `alice/_knop/_inventory` advancement to `_s0002` while keeping `_mesh/_inventory/inventory.ttl` unchanged.
+- [x] Add a black-box CLI acceptance test scoped by the settled `09-alice-bio-referenced-woven` Accord manifest.
+- [x] Update relevant overview/spec/framework notes as the slice settles.

--- a/documentation/notes/wd.task.2026.2026-04-04_2019-update-alice-bio-payload.md
+++ b/documentation/notes/wd.task.2026.2026-04-04_2019-update-alice-bio-payload.md
@@ -24,7 +24,7 @@ The target behavior is deliberately narrow:
 - update the existing working payload file `alice-bio.ttl` for the already managed payload artifact `alice/bio`
 - keep the working payload file at the existing root path rather than relocating it before the later woven `v2` slice
 - leave `alice/bio/_history001/_s0001/...` unchanged until the next `weave`
-- leave `_mesh/_inventory/inventory.ttl`, `alice/_knop/_inventory/inventory.ttl`, `alice/_knop/_references/references.ttl`, and `alice/bio/_knop/_inventory/inventory.ttl` unchanged
+- leave `_mesh/_inventory/inventory.ttl`, `alice/_knop/_inventory/inventory.ttl`, `alice/_knop/_references/references.ttl`, `alice/_knop/_references/index.html`, `alice/_knop/_references/_history001/...`, `alice/bio/index.html`, and `alice/bio/_knop/_inventory/inventory.ttl` unchanged
 - keep the change single-artifact and non-woven: in the settled `09` -> `10` fixture, no file other than `alice-bio.ttl` changes
 
 This task should prove the first semantic payload-update path without folding in `11-alice-bio-v2-woven`, Bob extraction, or generalized RDF-editing abstractions.
@@ -72,8 +72,9 @@ The first carried `payload.update` slice should update the bytes of the already 
 That means:
 
 - the target designator should already resolve to an existing integrated payload artifact
-- the local runtime should resolve the existing working located file for that payload artifact
+- the local runtime should resolve the existing working located file for that payload artifact from the already-versioned payload surface rather than treating existing history as an unsupported shape
 - the current slice should not invent a patch language, relocate the working file, or create a new historical snapshot before the later `11` weave
+- the current slice should not route through any page-regeneration path; the `09` catalog and payload pages are frozen context for this semantic update, not outputs of it
 
 ## Resolved Questions
 
@@ -81,6 +82,7 @@ That means:
 - `payload.update` should get a dedicated `wd.spec.*` note before implementation rather than being folded into the weave note.
 - The first local request/result boundary should stay narrow around an existing payload `designatorPath` plus a replacement source input, while keeping host staging and file-replacement details in the local runtime rather than shared `core`.
 - The first carried slice should update the existing working payload bytes in place rather than introducing a general RDF diff or patch abstraction.
+- The first carried slice should treat the existing `alice/bio` payload artifact history and the frozen `09` generated pages as normal preconditions, not as signals that the runtime is already “too woven” to update.
 - The current local validation floor should stay narrow: changed RDF should parse cleanly and match the settled fixture semantics, while broader merged-graph or SHACL validation remains a later concern.
 
 ## Decisions
@@ -91,7 +93,7 @@ That means:
 - Keep the first `payload.update` implementation local or in-process over shared `core` and `runtime`.
 - Keep the slice single-artifact and non-woven: in the settled acceptance target, only `alice-bio.ttl` should change.
 - Preserve the current working file placement at `alice-bio.ttl` for this first slice.
-- Leave `alice/bio/_history001/_s0001/...`, `_mesh/_inventory/inventory.ttl`, `alice/_knop/_inventory/inventory.ttl`, `alice/_knop/_references/references.ttl`, and `alice/bio/_knop/_inventory/inventory.ttl` unchanged in this non-woven step.
+- Leave `alice/bio/_history001/_s0001/...`, `_mesh/_inventory/inventory.ttl`, `alice/_knop/_inventory/inventory.ttl`, `alice/_knop/_references/references.ttl`, `alice/_knop/_references/index.html`, `alice/_knop/_references/_history001/...`, `alice/bio/index.html`, and `alice/bio/_knop/_inventory/inventory.ttl` unchanged in this non-woven step.
 - Do not absorb `11-alice-bio-v2-woven`, Bob extraction, generic RDF patching, daemon work, or broader rendering ambitions into this task.
 
 ## Contract Changes
@@ -103,6 +105,7 @@ That means:
 
 - Follow [[wd.testing]].
 - Add failing unit tests for narrow `payload.update` planning and validation logic where practical.
+- Start with failing integration and black-box CLI tests against the settled `10-alice-bio-updated` fixture target so the single-file invariant is locked in before implementation.
 - Add integration tests for local filesystem results against the settled `10-alice-bio-updated` fixture target.
 - Add a black-box CLI acceptance test scoped by the settled `10-alice-bio-updated` Accord manifest.
 - Keep the comparison black-box and fixture-oriented, with strong checks that untouched support artifacts remain unchanged.
@@ -120,10 +123,19 @@ That means:
 
 ## Implementation Plan
 
-- [ ] Draft [[wd.spec.2026-04-04-payload-update-behavior]] and settle the first local request/result boundary for `payload.update`.
-- [ ] Define the first local CLI surface for the carried `payload.update` operation.
-- [ ] Add failing unit and integration tests for the narrow `09` -> `10` payload-update behavior.
-- [ ] Implement the first local or in-process `payload.update` path over shared `core` and `runtime`.
-- [ ] Add a black-box CLI acceptance test scoped by the settled `10-alice-bio-updated` Accord manifest.
-- [ ] Draft or refine the thin public API example or contract fragment for `payload.update` in `semantic-flow-framework` if this slice sharpens the public contract.
-- [ ] Update relevant overview/spec/framework notes as the slice settles.
+- [x] Draft [[wd.spec.2026-04-04-payload-update-behavior]] and settle the first local request/result boundary for `payload.update`.
+- [x] Define the first local CLI surface for the carried `payload.update` operation.
+- [x] Add failing integration and black-box CLI tests for the narrow `09` -> `10` payload-update behavior, then add unit tests where a real planning or validation seam appears.
+- [x] Implement the first local or in-process `payload.update` path over shared `core` and `runtime`.
+- [x] Draft or refine the thin public API example or contract fragment for `payload.update` in `semantic-flow-framework` if this slice sharpens the public contract.
+- [x] Update relevant overview/spec/framework notes as the slice settles.
+
+## Outcome
+
+The carried `09-alice-bio-referenced-woven` -> `10-alice-bio-updated` slice is now implemented locally.
+
+- `payload.update` now has a dedicated behavior note at [[wd.spec.2026-04-04-payload-update-behavior]].
+- the first local CLI surface is `weave payload update <source> [designatorPath]`, with `--designator-path` as the explicit option form
+- shared `core` now plans replacement of the already managed working payload file for an existing woven payload artifact, while local `runtime` resolves the workspace state and stages replacement bytes from a local path or `file:` URL
+- the carried implementation keeps the settled `10` invariant: only `alice-bio.ttl` changes, while `_mesh/_inventory/inventory.ttl`, Knop inventories, historical payload snapshots, and generated pages remain unchanged
+- focused unit, integration, and black-box CLI coverage now lock the slice against the settled `10-alice-bio-updated` manifest and fixture

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -5,6 +5,7 @@ import { IntegrateInputError } from "../core/integrate/integrate.ts";
 import { KnopAddReferenceInputError } from "../core/knop/add_reference.ts";
 import { KnopCreateInputError } from "../core/knop/create.ts";
 import { MeshCreateInputError } from "../core/mesh/create.ts";
+import { PayloadUpdateInputError } from "../core/payload/update.ts";
 import { WeaveInputError } from "../core/weave/weave.ts";
 import { createRuntimeLoggers } from "../runtime/logging/factory.ts";
 import {
@@ -27,6 +28,11 @@ import {
   executeMeshCreate,
   MeshCreateRuntimeError,
 } from "../runtime/mesh/create.ts";
+import {
+  describePayloadUpdateResult,
+  executePayloadUpdate,
+  PayloadUpdateRuntimeError,
+} from "../runtime/payload/update.ts";
 import {
   describeWeaveResult,
   executeWeave,
@@ -121,6 +127,60 @@ export async function runWeaveCli(args: string[]): Promise<number> {
             console.log(path);
           }
         }),
+    )
+    .command(
+      "payload",
+      new Command()
+        .description("Payload operations.")
+        .command(
+          "update",
+          new Command()
+            .description(
+              "Replace the working bytes of an existing payload artifact.",
+            )
+            .arguments("<source:string> [designatorPath:string]")
+            .option(
+              "--designator-path <designatorPath:string>",
+              "Designator path of the existing payload artifact to update.",
+            )
+            .option(
+              "--workspace <workspace:string>",
+              "Workspace root to update.",
+              { default: "." },
+            )
+            .action(async (options, source, designatorPathArg) => {
+              const workspaceRoot = resolve(options.workspace);
+              const designatorPath = resolvePayloadUpdateDesignatorPath(
+                options,
+                designatorPathArg,
+              );
+              const logDir = join(workspaceRoot, ".weave", "logs");
+              const { operationalLogger, auditLogger } = createRuntimeLoggers({
+                logDir,
+              });
+
+              await auditLogger.command("payload.update", {
+                workspaceRoot,
+                designatorPath,
+                source,
+                localMode: true,
+              });
+
+              const result = await executePayloadUpdate({
+                workspaceRoot,
+                request: {
+                  designatorPath,
+                  source,
+                },
+                operationalLogger,
+                auditLogger,
+              });
+              console.log(describePayloadUpdateResult(result));
+              for (const path of result.updatedPaths) {
+                console.log(path);
+              }
+            }),
+        ),
     )
     .command(
       "mesh",
@@ -349,10 +409,42 @@ function resolveIntegrateDesignatorPath(
   );
 }
 
+function resolvePayloadUpdateDesignatorPath(
+  options: { designatorPath?: string },
+  designatorPathArg?: string,
+): string {
+  const optionValue = options.designatorPath?.trim() ?? "";
+  const argumentValue = designatorPathArg?.trim() ?? "";
+
+  if (optionValue.length > 0 && argumentValue.length > 0) {
+    if (optionValue !== argumentValue) {
+      throw new PayloadUpdateInputError(
+        "payload update received conflicting designator paths",
+      );
+    }
+
+    return optionValue;
+  }
+
+  if (optionValue.length > 0) {
+    return optionValue;
+  }
+
+  if (argumentValue.length > 0) {
+    return argumentValue;
+  }
+
+  throw new PayloadUpdateInputError(
+    "payload update requires a designator path as [designatorPath] or --designator-path",
+  );
+}
+
 function getCliErrorMessage(error: unknown): string {
   if (
     error instanceof IntegrateInputError ||
     error instanceof IntegrateRuntimeError ||
+    error instanceof PayloadUpdateInputError ||
+    error instanceof PayloadUpdateRuntimeError ||
     error instanceof KnopAddReferenceInputError ||
     error instanceof KnopAddReferenceRuntimeError ||
     error instanceof WeaveInputError ||

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -383,44 +383,41 @@ function resolveIntegrateDesignatorPath(
   options: { designatorPath?: string },
   designatorPathArg?: string,
 ): string {
-  const optionValue = options.designatorPath?.trim() ?? "";
-  const argumentValue = designatorPathArg?.trim() ?? "";
-
-  if (optionValue.length > 0 && argumentValue.length > 0) {
-    if (optionValue !== argumentValue) {
-      throw new IntegrateInputError(
-        "integrate received conflicting designator paths",
-      );
-    }
-
-    return optionValue;
-  }
-
-  if (optionValue.length > 0) {
-    return optionValue;
-  }
-
-  if (argumentValue.length > 0) {
-    return argumentValue;
-  }
-
-  throw new IntegrateInputError(
-    "integrate requires a designator path as [designatorPath] or --designator-path",
-  );
+  return resolveDesignatorPath(options, designatorPathArg, {
+    conflictMessage: "integrate received conflicting designator paths",
+    missingMessage:
+      "integrate requires a designator path as [designatorPath] or --designator-path",
+    createError: (message) => new IntegrateInputError(message),
+  });
 }
 
 function resolvePayloadUpdateDesignatorPath(
   options: { designatorPath?: string },
   designatorPathArg?: string,
 ): string {
+  return resolveDesignatorPath(options, designatorPathArg, {
+    conflictMessage: "payload update received conflicting designator paths",
+    missingMessage:
+      "payload update requires a designator path as [designatorPath] or --designator-path",
+    createError: (message) => new PayloadUpdateInputError(message),
+  });
+}
+
+function resolveDesignatorPath(
+  options: { designatorPath?: string },
+  designatorPathArg: string | undefined,
+  errorMessages: {
+    conflictMessage: string;
+    missingMessage: string;
+    createError: (message: string) => Error;
+  },
+): string {
   const optionValue = options.designatorPath?.trim() ?? "";
   const argumentValue = designatorPathArg?.trim() ?? "";
 
   if (optionValue.length > 0 && argumentValue.length > 0) {
     if (optionValue !== argumentValue) {
-      throw new PayloadUpdateInputError(
-        "payload update received conflicting designator paths",
-      );
+      throw errorMessages.createError(errorMessages.conflictMessage);
     }
 
     return optionValue;
@@ -434,9 +431,7 @@ function resolvePayloadUpdateDesignatorPath(
     return argumentValue;
   }
 
-  throw new PayloadUpdateInputError(
-    "payload update requires a designator path as [designatorPath] or --designator-path",
-  );
+  throw errorMessages.createError(errorMessages.missingMessage);
 }
 
 function getCliErrorMessage(error: unknown): string {

--- a/src/core/designator_segments.ts
+++ b/src/core/designator_segments.ts
@@ -1,0 +1,4 @@
+export const RESERVED_DESIGNATOR_SEGMENTS: ReadonlySet<string> = new Set([
+  "_knop",
+  "_mesh",
+]);

--- a/src/core/mod.ts
+++ b/src/core/mod.ts
@@ -2,4 +2,5 @@ export * from "./planned_file.ts";
 export * from "./integrate/mod.ts";
 export * from "./knop/mod.ts";
 export * from "./mesh/mod.ts";
+export * from "./payload/mod.ts";
 export * from "./weave/mod.ts";

--- a/src/core/payload/mod.ts
+++ b/src/core/payload/mod.ts
@@ -1,0 +1,1 @@
+export * from "./update.ts";

--- a/src/core/payload/update.ts
+++ b/src/core/payload/update.ts
@@ -1,6 +1,10 @@
+import { Parser, type Quad } from "n3";
+import { RESERVED_DESIGNATOR_SEGMENTS } from "../designator_segments.ts";
 import type { PlannedFile } from "../planned_file.ts";
 
-const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
+const RDF_TYPE_IRI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const SFLO_NAMESPACE =
+  "https://semantic-flow.github.io/semantic-flow-ontology/";
 
 export interface PayloadUpdateRequest {
   designatorPath: string;
@@ -110,7 +114,7 @@ function normalizeDesignatorPath(designatorPath: string): string {
       "designatorPath must not contain '.' or '..' path segments",
     );
   }
-  if (segments.some((segment) => reservedDesignatorSegments.has(segment))) {
+  if (segments.some((segment) => RESERVED_DESIGNATOR_SEGMENTS.has(segment))) {
     throw new PayloadUpdateInputError(
       "designatorPath must not contain reserved path segments",
     );
@@ -170,18 +174,108 @@ function assertCurrentPayloadArtifactShape(
 ): void {
   const knopPath = `${designatorPath}/_knop`;
   const requiredFragments = [
-    `<${knopPath}> a sflo:Knop ;`,
-    `sflo:hasPayloadArtifact <${designatorPath}> ;`,
-    `<${designatorPath}> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;`,
-    `sflo:hasWorkingLocatedFile <${workingFilePath}> ;`,
-    `sflo:currentArtifactHistory <${designatorPath}/_history001> ;`,
+    {
+      subject: toIriCandidates(currentKnopInventoryTurtle, knopPath),
+      predicate: [RDF_TYPE_IRI],
+      object: [`${SFLO_NAMESPACE}Knop`],
+    },
+    {
+      subject: toIriCandidates(currentKnopInventoryTurtle, knopPath),
+      predicate: [`${SFLO_NAMESPACE}hasPayloadArtifact`],
+      object: toIriCandidates(currentKnopInventoryTurtle, designatorPath),
+    },
+    {
+      subject: toIriCandidates(currentKnopInventoryTurtle, designatorPath),
+      predicate: [RDF_TYPE_IRI],
+      object: [`${SFLO_NAMESPACE}PayloadArtifact`],
+    },
+    {
+      subject: toIriCandidates(currentKnopInventoryTurtle, designatorPath),
+      predicate: [RDF_TYPE_IRI],
+      object: [`${SFLO_NAMESPACE}DigitalArtifact`],
+    },
+    {
+      subject: toIriCandidates(currentKnopInventoryTurtle, designatorPath),
+      predicate: [RDF_TYPE_IRI],
+      object: [`${SFLO_NAMESPACE}RdfDocument`],
+    },
+    {
+      subject: toIriCandidates(currentKnopInventoryTurtle, designatorPath),
+      predicate: [`${SFLO_NAMESPACE}hasWorkingLocatedFile`],
+      object: toIriCandidates(currentKnopInventoryTurtle, workingFilePath),
+    },
+    {
+      subject: toIriCandidates(currentKnopInventoryTurtle, designatorPath),
+      predicate: [`${SFLO_NAMESPACE}currentArtifactHistory`],
+      object: toIriCandidates(
+        currentKnopInventoryTurtle,
+        `${designatorPath}/_history001`,
+      ),
+    },
   ];
+  const quadKeys = parseQuadKeys(currentKnopInventoryTurtle, designatorPath);
 
   for (const fragment of requiredFragments) {
-    if (!currentKnopInventoryTurtle.includes(fragment)) {
+    if (!quadSetHasAnyMatch(quadKeys, fragment)) {
       throw new PayloadUpdateInputError(
         `The current local payload.update slice only supports the settled woven payload shape for ${designatorPath}.`,
       );
     }
   }
+}
+
+function parseQuadKeys(
+  currentKnopInventoryTurtle: string,
+  designatorPath: string,
+): ReadonlySet<string> {
+  try {
+    return new Set(
+      new Parser().parse(currentKnopInventoryTurtle).map((quad: Quad) =>
+        toQuadKey(quad.subject.value, quad.predicate.value, quad.object.value)
+      ),
+    );
+  } catch {
+    throw new PayloadUpdateInputError(
+      `The current local payload.update slice only supports the settled woven payload shape for ${designatorPath}.`,
+    );
+  }
+}
+
+function quadSetHasAnyMatch(
+  quadKeys: ReadonlySet<string>,
+  fragment: {
+    subject: readonly string[];
+    predicate: readonly string[];
+    object: readonly string[];
+  },
+): boolean {
+  for (const subject of fragment.subject) {
+    for (const predicate of fragment.predicate) {
+      for (const object of fragment.object) {
+        if (quadKeys.has(toQuadKey(subject, predicate, object))) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function toIriCandidates(
+  currentKnopInventoryTurtle: string,
+  value: string,
+): readonly string[] {
+  const candidates = new Set<string>([value]);
+  const baseIri = currentKnopInventoryTurtle.match(/^@base <([^>]+)> \./m)?.[1];
+
+  if (baseIri) {
+    candidates.add(new URL(value, baseIri).href);
+  }
+
+  return [...candidates];
+}
+
+function toQuadKey(subject: string, predicate: string, object: string): string {
+  return `${subject} ${predicate} ${object}`;
 }

--- a/src/core/payload/update.ts
+++ b/src/core/payload/update.ts
@@ -1,0 +1,187 @@
+import type { PlannedFile } from "../planned_file.ts";
+
+const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
+
+export interface PayloadUpdateRequest {
+  designatorPath: string;
+  workingFilePath: string;
+  replacementPayloadTurtle: string;
+}
+
+export interface ResolvedPayloadUpdateRequest extends PayloadUpdateRequest {
+  meshBase: string;
+  currentKnopInventoryTurtle: string;
+}
+
+export interface PayloadUpdatePlan {
+  meshBase: string;
+  designatorPath: string;
+  payloadArtifactIri: string;
+  workingFilePath: string;
+  updatedFiles: readonly PlannedFile[];
+}
+
+export class PayloadUpdateInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PayloadUpdateInputError";
+  }
+}
+
+export function planPayloadUpdate(
+  request: ResolvedPayloadUpdateRequest,
+): PayloadUpdatePlan {
+  const meshBase = normalizeMeshBase(request.meshBase);
+  const designatorPath = normalizeDesignatorPath(request.designatorPath);
+  const workingFilePath = normalizeWorkingFilePath(request.workingFilePath);
+  const replacementPayloadTurtle = normalizeReplacementPayloadTurtle(
+    request.replacementPayloadTurtle,
+  );
+
+  assertCurrentPayloadArtifactShape(
+    request.currentKnopInventoryTurtle,
+    designatorPath,
+    workingFilePath,
+  );
+
+  return {
+    meshBase,
+    designatorPath,
+    payloadArtifactIri: new URL(designatorPath, meshBase).href,
+    workingFilePath,
+    updatedFiles: [{
+      path: workingFilePath,
+      contents: replacementPayloadTurtle,
+    }],
+  };
+}
+
+function normalizeMeshBase(meshBase: string): string {
+  const trimmed = meshBase.trim();
+  if (trimmed.length === 0) {
+    throw new PayloadUpdateInputError("meshBase is required");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new PayloadUpdateInputError("meshBase must be an absolute IRI");
+  }
+
+  if (!url.pathname.endsWith("/")) {
+    throw new PayloadUpdateInputError("meshBase must end with '/'");
+  }
+  if (url.search.length > 0 || url.hash.length > 0) {
+    throw new PayloadUpdateInputError(
+      "meshBase must not include a query or fragment",
+    );
+  }
+
+  return url.href;
+}
+
+function normalizeDesignatorPath(designatorPath: string): string {
+  const trimmed = designatorPath.trim();
+  if (trimmed.length === 0) {
+    throw new PayloadUpdateInputError("designatorPath is required");
+  }
+  if (trimmed.startsWith("/") || trimmed.endsWith("/")) {
+    throw new PayloadUpdateInputError(
+      "designatorPath must not start or end with '/'",
+    );
+  }
+  if (
+    trimmed.includes("\\") || trimmed.includes("?") || trimmed.includes("#")
+  ) {
+    throw new PayloadUpdateInputError(
+      "designatorPath contains unsupported path characters",
+    );
+  }
+
+  const segments = trimmed.split("/");
+  if (segments.some((segment) => segment.length === 0)) {
+    throw new PayloadUpdateInputError(
+      "designatorPath must not contain empty path segments",
+    );
+  }
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new PayloadUpdateInputError(
+      "designatorPath must not contain '.' or '..' path segments",
+    );
+  }
+  if (segments.some((segment) => reservedDesignatorSegments.has(segment))) {
+    throw new PayloadUpdateInputError(
+      "designatorPath must not contain reserved path segments",
+    );
+  }
+
+  return trimmed;
+}
+
+function normalizeWorkingFilePath(workingFilePath: string): string {
+  const trimmed = workingFilePath.trim();
+  if (trimmed.length === 0) {
+    throw new PayloadUpdateInputError("workingFilePath is required");
+  }
+  if (trimmed.startsWith("/") || trimmed.endsWith("/")) {
+    throw new PayloadUpdateInputError(
+      "workingFilePath must be a mesh-relative file path",
+    );
+  }
+  if (
+    trimmed.includes("\\") || trimmed.includes("?") || trimmed.includes("#") ||
+    /\s/.test(trimmed)
+  ) {
+    throw new PayloadUpdateInputError(
+      "workingFilePath contains unsupported path characters",
+    );
+  }
+
+  const segments = trimmed.split("/");
+  if (segments.some((segment) => segment.length === 0)) {
+    throw new PayloadUpdateInputError(
+      "workingFilePath must not contain empty path segments",
+    );
+  }
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new PayloadUpdateInputError(
+      "workingFilePath must be a mesh-relative file path",
+    );
+  }
+
+  return trimmed;
+}
+
+function normalizeReplacementPayloadTurtle(
+  replacementPayloadTurtle: string,
+): string {
+  if (replacementPayloadTurtle.trim().length === 0) {
+    throw new PayloadUpdateInputError("replacement payload bytes are required");
+  }
+
+  return replacementPayloadTurtle;
+}
+
+function assertCurrentPayloadArtifactShape(
+  currentKnopInventoryTurtle: string,
+  designatorPath: string,
+  workingFilePath: string,
+): void {
+  const knopPath = `${designatorPath}/_knop`;
+  const requiredFragments = [
+    `<${knopPath}> a sflo:Knop ;`,
+    `sflo:hasPayloadArtifact <${designatorPath}> ;`,
+    `<${designatorPath}> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;`,
+    `sflo:hasWorkingLocatedFile <${workingFilePath}> ;`,
+    `sflo:currentArtifactHistory <${designatorPath}/_history001> ;`,
+  ];
+
+  for (const fragment of requiredFragments) {
+    if (!currentKnopInventoryTurtle.includes(fragment)) {
+      throw new PayloadUpdateInputError(
+        `The current local payload.update slice only supports the settled woven payload shape for ${designatorPath}.`,
+      );
+    }
+  }
+}

--- a/src/core/payload/update_test.ts
+++ b/src/core/payload/update_test.ts
@@ -49,3 +49,26 @@ Deno.test("planPayloadUpdate rejects an inventory that does not resolve the wove
     "settled woven payload shape",
   );
 });
+
+Deno.test("planPayloadUpdate accepts semantically equivalent woven payload inventory turtle", () => {
+  const plan = planPayloadUpdate({
+    designatorPath: "alice/bio",
+    workingFilePath: "alice-bio.ttl",
+    replacementPayloadTurtle: "@base <https://example.org/> .\n",
+    meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+    currentKnopInventoryTurtle:
+      `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+
+<alice/bio> sflo:currentArtifactHistory <alice/bio/_history001> ;
+  sflo:hasWorkingLocatedFile <alice-bio.ttl> ;
+  rdf:type sflo:RdfDocument, sflo:DigitalArtifact, sflo:PayloadArtifact .
+
+<alice/bio/_knop> sflo:hasPayloadArtifact <alice/bio> ;
+  rdf:type sflo:Knop .
+`,
+  });
+
+  assertEquals(plan.updatedFiles.map((file) => file.path), ["alice-bio.ttl"]);
+});

--- a/src/core/payload/update_test.ts
+++ b/src/core/payload/update_test.ts
@@ -29,7 +29,7 @@ Deno.test("planPayloadUpdate renders the first payload-update slice", async () =
   );
 });
 
-Deno.test("planPayloadUpdate rejects an inventory that does not resolve the woven payload artifact", async () => {
+Deno.test("planPayloadUpdate rejects an inventory that does not resolve the woven payload artifact", () => {
   assertThrows(
     () =>
       planPayloadUpdate({

--- a/src/core/payload/update_test.ts
+++ b/src/core/payload/update_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { readMeshAliceBioBranchFile } from "../../../tests/support/mesh_alice_bio_fixture.ts";
+import { PayloadUpdateInputError, planPayloadUpdate } from "./update.ts";
+
+Deno.test("planPayloadUpdate renders the first payload-update slice", async () => {
+  const plan = planPayloadUpdate({
+    designatorPath: "alice/bio",
+    workingFilePath: "alice-bio.ttl",
+    replacementPayloadTurtle: await readMeshAliceBioBranchFile(
+      "10-alice-bio-updated",
+      "alice-bio.ttl",
+    ),
+    meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+    currentKnopInventoryTurtle: await readMeshAliceBioBranchFile(
+      "09-alice-bio-referenced-woven",
+      "alice/bio/_knop/_inventory/inventory.ttl",
+    ),
+  });
+
+  assertEquals(
+    plan.payloadArtifactIri,
+    "https://semantic-flow.github.io/mesh-alice-bio/alice/bio",
+  );
+  assertEquals(plan.workingFilePath, "alice-bio.ttl");
+  assertEquals(plan.updatedFiles.map((file) => file.path), ["alice-bio.ttl"]);
+  assertEquals(
+    plan.updatedFiles[0]?.contents,
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+});
+
+Deno.test("planPayloadUpdate rejects an inventory that does not resolve the woven payload artifact", async () => {
+  assertThrows(
+    () =>
+      planPayloadUpdate({
+        designatorPath: "alice/bio",
+        workingFilePath: "alice-bio.ttl",
+        replacementPayloadTurtle: "@base <https://example.org/> .\n",
+        meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+        currentKnopInventoryTurtle:
+          `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+
+<alice/bio/_knop> a sflo:Knop ;
+  sflo:hasKnopInventory <alice/bio/_knop/_inventory> .
+`,
+      }),
+    PayloadUpdateInputError,
+    "settled woven payload shape",
+  );
+});

--- a/src/core/weave/weave.ts
+++ b/src/core/weave/weave.ts
@@ -76,7 +76,7 @@ export class WeaveInputError extends Error {
   }
 }
 
-type WeaveSlice =
+export type WeaveSlice =
   | "firstKnopWeave"
   | "firstPayloadWeave"
   | "firstReferenceCatalogWeave";
@@ -196,46 +196,59 @@ function filterWeaveableKnops(
 function classifyWeaveSlice(
   candidate: WeaveableKnopCandidate,
 ): WeaveSlice | undefined {
-  const designatorPath = candidate.designatorPath;
+  const slice = detectPendingWeaveSlice(
+    candidate.designatorPath,
+    candidate.currentKnopInventoryTurtle,
+  );
+
+  if (
+    slice === "firstReferenceCatalogWeave" &&
+    !candidate.referenceCatalogArtifact
+  ) {
+    throw new WeaveInputError(
+      `ReferenceCatalog weave candidate ${candidate.designatorPath} is missing working catalog state.`,
+    );
+  }
+
+  if (slice === "firstPayloadWeave" && !candidate.payloadArtifact) {
+    throw new WeaveInputError(
+      `Payload weave candidate ${candidate.designatorPath} is missing working payload state.`,
+    );
+  }
+
+  return slice;
+}
+
+export function detectPendingWeaveSlice(
+  designatorPath: string,
+  currentKnopInventoryTurtle: string,
+): WeaveSlice | undefined {
   const knopPath = toKnopPath(designatorPath);
   const payloadRelationship = `sflo:hasPayloadArtifact <${designatorPath}>`;
-  const payloadHasHistory = candidate.currentKnopInventoryTurtle.includes(
+  const payloadHasHistory = currentKnopInventoryTurtle.includes(
     `sflo:hasArtifactHistory <${designatorPath}/_history001>`,
   );
   const referenceCatalogPath = `${knopPath}/_references`;
   const referenceCatalogRelationship =
     `sflo:hasReferenceCatalog <${referenceCatalogPath}>`;
-  const referenceCatalogHasHistory = candidate.currentKnopInventoryTurtle
-    .includes(`sflo:hasArtifactHistory <${referenceCatalogPath}/_history001>`);
-  const knopInventoryHasHistory = candidate.currentKnopInventoryTurtle.includes(
+  const referenceCatalogHasHistory = currentKnopInventoryTurtle.includes(
+    `sflo:hasArtifactHistory <${referenceCatalogPath}/_history001>`,
+  );
+  const knopInventoryHasHistory = currentKnopInventoryTurtle.includes(
     `sflo:hasArtifactHistory <${knopPath}/_inventory/_history001>`,
   );
 
   if (
-    candidate.currentKnopInventoryTurtle.includes(
-      referenceCatalogRelationship,
-    ) &&
+    currentKnopInventoryTurtle.includes(referenceCatalogRelationship) &&
     !referenceCatalogHasHistory
   ) {
-    if (!candidate.referenceCatalogArtifact) {
-      throw new WeaveInputError(
-        `ReferenceCatalog weave candidate ${designatorPath} is missing working catalog state.`,
-      );
-    }
-
     return "firstReferenceCatalogWeave";
   }
 
   if (
-    candidate.currentKnopInventoryTurtle.includes(payloadRelationship) &&
+    currentKnopInventoryTurtle.includes(payloadRelationship) &&
     !payloadHasHistory
   ) {
-    if (!candidate.payloadArtifact) {
-      throw new WeaveInputError(
-        `Payload weave candidate ${designatorPath} is missing working payload state.`,
-      );
-    }
-
     return "firstPayloadWeave";
   }
 
@@ -409,6 +422,12 @@ function planFirstReferenceCatalogWeave(
   const designatorPath = candidate.designatorPath;
   const knopPath = toKnopPath(designatorPath);
   const referenceCatalogPath = `${knopPath}/_references`;
+  const referenceCatalogWorkingFilePath = referenceCatalogArtifact
+    .workingFilePath;
+  const referenceCatalogManifestationPath = toArtifactManifestationPath(
+    `${referenceCatalogPath}/_history001/_s0001`,
+    referenceCatalogWorkingFilePath,
+  );
   const referenceCatalogLinks = extractCurrentReferenceCatalogLinks(
     referenceCatalogArtifact.currentReferenceCatalogTurtle,
     designatorPath,
@@ -425,11 +444,13 @@ function planFirstReferenceCatalogWeave(
         contents: renderFirstReferenceCatalogWovenKnopInventoryTurtle(
           meshBase,
           designatorPath,
+          referenceCatalogWorkingFilePath,
         ),
       },
       {
-        path:
-          `${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl`,
+        path: `${referenceCatalogManifestationPath}/${
+          toFileName(referenceCatalogWorkingFilePath)
+        }`,
         contents: referenceCatalogArtifact.currentReferenceCatalogTurtle,
       },
     ],
@@ -439,11 +460,13 @@ function planFirstReferenceCatalogWeave(
         contents: renderFirstReferenceCatalogWovenKnopInventoryTurtle(
           meshBase,
           designatorPath,
+          referenceCatalogWorkingFilePath,
         ),
       },
     ],
     createdPages: buildFirstReferenceCatalogWeavePages(
       designatorPath,
+      referenceCatalogWorkingFilePath,
       referenceCatalogLinks,
     ),
   };
@@ -1204,9 +1227,14 @@ function renderFirstPayloadWovenKnopInventoryTurtle(
 function renderFirstReferenceCatalogWovenKnopInventoryTurtle(
   meshBase: string,
   designatorPath: string,
+  workingFilePath: string,
 ): string {
   const knopPath = toKnopPath(designatorPath);
   const referenceCatalogPath = `${knopPath}/_references`;
+  const referenceCatalogManifestationPath = toArtifactManifestationPath(
+    `${referenceCatalogPath}/_history001/_s0001`,
+    workingFilePath,
+  );
 
   return `@base <${meshBase}> .
 @prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
@@ -1254,7 +1282,7 @@ function renderFirstReferenceCatalogWovenKnopInventoryTurtle(
   sflo:hasArtifactHistory <${referenceCatalogPath}/_history001> ;
   sflo:currentArtifactHistory <${referenceCatalogPath}/_history001> ;
   sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
-  sflo:hasWorkingLocatedFile <${referenceCatalogPath}/references.ttl> ;
+  sflo:hasWorkingLocatedFile <${workingFilePath}> ;
   sflo:hasResourcePage <${referenceCatalogPath}/index.html> .
 
 <${knopPath}/_inventory/_history001> a sflo:ArtifactHistory ;
@@ -1295,19 +1323,23 @@ function renderFirstReferenceCatalogWovenKnopInventoryTurtle(
 
 <${referenceCatalogPath}/_history001/_s0001> a sflo:HistoricalState ;
   sflo:stateOrdinal "1"^^xsd:nonNegativeInteger ;
-  sflo:hasManifestation <${referenceCatalogPath}/_history001/_s0001/references-ttl> ;
-  sflo:locatedFileForState <${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl> ;
+  sflo:hasManifestation <${referenceCatalogManifestationPath}> ;
+  sflo:locatedFileForState <${referenceCatalogManifestationPath}/${
+    toFileName(workingFilePath)
+  }> ;
   sflo:hasResourcePage <${referenceCatalogPath}/_history001/_s0001/index.html> .
 
-<${referenceCatalogPath}/_history001/_s0001/references-ttl> a sflo:ArtifactManifestation, sflo:RdfDocument ;
-  sflo:hasLocatedFile <${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl> ;
-  sflo:hasResourcePage <${referenceCatalogPath}/_history001/_s0001/references-ttl/index.html> .
+<${referenceCatalogManifestationPath}> a sflo:ArtifactManifestation, sflo:RdfDocument ;
+  sflo:hasLocatedFile <${referenceCatalogManifestationPath}/${
+    toFileName(workingFilePath)
+  }> ;
+  sflo:hasResourcePage <${referenceCatalogManifestationPath}/index.html> .
 
 <${knopPath}/_meta/meta.ttl> a sflo:LocatedFile, sflo:RdfDocument .
 
 <${knopPath}/_inventory/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
 
-<${referenceCatalogPath}/references.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+<${workingFilePath}> a sflo:LocatedFile, sflo:RdfDocument .
 
 <${knopPath}/_meta/_history001/_s0001/meta-ttl/meta.ttl> a sflo:LocatedFile, sflo:RdfDocument .
 
@@ -1315,7 +1347,9 @@ function renderFirstReferenceCatalogWovenKnopInventoryTurtle(
 
 <${knopPath}/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
 
-<${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+<${referenceCatalogManifestationPath}/${
+    toFileName(workingFilePath)
+  }> a sflo:LocatedFile, sflo:RdfDocument .
 
 <${knopPath}/index.html> a sflo:ResourcePage, sflo:LocatedFile .
 
@@ -1345,7 +1379,7 @@ function renderFirstReferenceCatalogWovenKnopInventoryTurtle(
 
 <${referenceCatalogPath}/_history001/_s0001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
 
-<${referenceCatalogPath}/_history001/_s0001/references-ttl/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+<${referenceCatalogManifestationPath}/index.html> a sflo:ResourcePage, sflo:LocatedFile .
 `;
 }
 
@@ -1480,10 +1514,15 @@ function buildFirstPayloadWeavePages(
 
 function buildFirstReferenceCatalogWeavePages(
   designatorPath: string,
+  workingFilePath: string,
   currentLinks: readonly ReferenceCatalogCurrentLinkModel[],
 ): readonly ResourcePageModel[] {
   const knopPath = toKnopPath(designatorPath);
   const referenceCatalogPath = `${knopPath}/_references`;
+  const referenceCatalogManifestationPath = toArtifactManifestationPath(
+    `${referenceCatalogPath}/_history001/_s0001`,
+    workingFilePath,
+  );
 
   return [
     simplePage(
@@ -1509,7 +1548,7 @@ function buildFirstReferenceCatalogWeavePages(
       `Resource page for the first ${designatorPath} ReferenceCatalog historical state.`,
     ),
     simplePage(
-      `${referenceCatalogPath}/_history001/_s0001/references-ttl/index.html`,
+      `${referenceCatalogManifestationPath}/index.html`,
       `Resource page for the Turtle manifestation of the first ${designatorPath} ReferenceCatalog historical state.`,
     ),
   ];
@@ -1558,9 +1597,17 @@ function toPayloadManifestationPath(
   designatorPath: string,
   workingFilePath: string,
 ): string {
-  return `${designatorPath}/_history001/_s0001/${
-    toManifestationSegment(workingFilePath)
-  }`;
+  return toArtifactManifestationPath(
+    `${designatorPath}/_history001/_s0001`,
+    workingFilePath,
+  );
+}
+
+function toArtifactManifestationPath(
+  historyStatePath: string,
+  workingFilePath: string,
+): string {
+  return `${historyStatePath}/${toManifestationSegment(workingFilePath)}`;
 }
 
 function toManifestationSegment(workingFilePath: string): string {

--- a/src/core/weave/weave.ts
+++ b/src/core/weave/weave.ts
@@ -9,11 +9,17 @@ export interface PayloadWorkingArtifact {
   currentPayloadTurtle: string;
 }
 
+export interface ReferenceCatalogWorkingArtifact {
+  workingFilePath: string;
+  currentReferenceCatalogTurtle: string;
+}
+
 export interface WeaveableKnopCandidate {
   designatorPath: string;
   currentKnopMetadataTurtle: string;
   currentKnopInventoryTurtle: string;
   payloadArtifact?: PayloadWorkingArtifact;
+  referenceCatalogArtifact?: ReferenceCatalogWorkingArtifact;
 }
 
 export interface IdentifierResourcePageModel {
@@ -29,9 +35,24 @@ export interface SimpleResourcePageModel {
   description: string;
 }
 
+export interface ReferenceCatalogCurrentLinkModel {
+  fragment: string;
+  referenceRoleLabel: string;
+  referenceTargetPath: string;
+}
+
+export interface ReferenceCatalogResourcePageModel {
+  kind: "referenceCatalog";
+  path: string;
+  catalogPath: string;
+  ownerDesignatorPath: string;
+  currentLinks: readonly ReferenceCatalogCurrentLinkModel[];
+}
+
 export type ResourcePageModel =
   | IdentifierResourcePageModel
-  | SimpleResourcePageModel;
+  | SimpleResourcePageModel
+  | ReferenceCatalogResourcePageModel;
 
 export interface PlanWeaveInput {
   request: WeaveRequest;
@@ -55,7 +76,10 @@ export class WeaveInputError extends Error {
   }
 }
 
-type WeaveSlice = "firstKnopWeave" | "firstPayloadWeave";
+type WeaveSlice =
+  | "firstKnopWeave"
+  | "firstPayloadWeave"
+  | "firstReferenceCatalogWeave";
 
 export function planWeave(input: PlanWeaveInput): WeavePlan {
   const meshBase = normalizeMeshBase(input.meshBase);
@@ -85,7 +109,7 @@ export function planWeave(input: PlanWeaveInput): WeavePlan {
     designatorPath,
     knopPath,
   );
-  assertCurrentKnopInventoryShape(
+  assertCurrentKnopInventoryBaseShape(
     candidate.currentKnopInventoryTurtle,
     knopPath,
   );
@@ -103,7 +127,17 @@ export function planWeave(input: PlanWeaveInput): WeavePlan {
         input.currentMeshInventoryTurtle,
         candidate,
       );
+    case "firstReferenceCatalogWeave":
+      return planFirstReferenceCatalogWeave(
+        meshBase,
+        input.currentMeshInventoryTurtle,
+        candidate,
+      );
   }
+
+  throw new WeaveInputError(
+    `No supported local weave slice was found for ${designatorPath}.`,
+  );
 }
 
 function normalizeMeshBase(meshBase: string): string {
@@ -159,19 +193,57 @@ function filterWeaveableKnops(
   return filtered;
 }
 
-function classifyWeaveSlice(candidate: WeaveableKnopCandidate): WeaveSlice {
-  const payloadRelationship =
-    `sflo:hasPayloadArtifact <${candidate.designatorPath}>`;
-  if (!candidate.currentKnopInventoryTurtle.includes(payloadRelationship)) {
-    return "firstKnopWeave";
-  }
-  if (!candidate.payloadArtifact) {
-    throw new WeaveInputError(
-      `Payload weave candidate ${candidate.designatorPath} is missing working payload state.`,
-    );
+function classifyWeaveSlice(
+  candidate: WeaveableKnopCandidate,
+): WeaveSlice | undefined {
+  const designatorPath = candidate.designatorPath;
+  const knopPath = toKnopPath(designatorPath);
+  const payloadRelationship = `sflo:hasPayloadArtifact <${designatorPath}>`;
+  const payloadHasHistory = candidate.currentKnopInventoryTurtle.includes(
+    `sflo:hasArtifactHistory <${designatorPath}/_history001>`,
+  );
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const referenceCatalogRelationship =
+    `sflo:hasReferenceCatalog <${referenceCatalogPath}>`;
+  const referenceCatalogHasHistory = candidate.currentKnopInventoryTurtle
+    .includes(`sflo:hasArtifactHistory <${referenceCatalogPath}/_history001>`);
+  const knopInventoryHasHistory = candidate.currentKnopInventoryTurtle.includes(
+    `sflo:hasArtifactHistory <${knopPath}/_inventory/_history001>`,
+  );
+
+  if (
+    candidate.currentKnopInventoryTurtle.includes(
+      referenceCatalogRelationship,
+    ) &&
+    !referenceCatalogHasHistory
+  ) {
+    if (!candidate.referenceCatalogArtifact) {
+      throw new WeaveInputError(
+        `ReferenceCatalog weave candidate ${designatorPath} is missing working catalog state.`,
+      );
+    }
+
+    return "firstReferenceCatalogWeave";
   }
 
-  return "firstPayloadWeave";
+  if (
+    candidate.currentKnopInventoryTurtle.includes(payloadRelationship) &&
+    !payloadHasHistory
+  ) {
+    if (!candidate.payloadArtifact) {
+      throw new WeaveInputError(
+        `Payload weave candidate ${designatorPath} is missing working payload state.`,
+      );
+    }
+
+    return "firstPayloadWeave";
+  }
+
+  if (!knopInventoryHasHistory) {
+    return "firstKnopWeave";
+  }
+
+  return undefined;
 }
 
 function planFirstKnopWeave(
@@ -179,6 +251,10 @@ function planFirstKnopWeave(
   currentMeshInventoryTurtle: string,
   candidate: WeaveableKnopCandidate,
 ): WeavePlan {
+  assertCurrentKnopInventoryWithoutHistory(
+    candidate.currentKnopInventoryTurtle,
+    toKnopPath(candidate.designatorPath),
+  );
   assertCurrentMeshInventoryShapeForFirstKnopWeave(currentMeshInventoryTurtle);
 
   const designatorPath = candidate.designatorPath;
@@ -236,6 +312,10 @@ function planFirstPayloadWeave(
   candidate: WeaveableKnopCandidate,
 ): WeavePlan {
   const payloadArtifact = candidate.payloadArtifact!;
+  assertCurrentKnopInventoryWithoutHistory(
+    candidate.currentKnopInventoryTurtle,
+    toKnopPath(candidate.designatorPath),
+  );
   assertCurrentMeshInventoryShapeForFirstPayloadWeave(
     currentMeshInventoryTurtle,
     candidate.designatorPath,
@@ -311,6 +391,64 @@ function planFirstPayloadWeave(
   };
 }
 
+function planFirstReferenceCatalogWeave(
+  meshBase: string,
+  currentMeshInventoryTurtle: string,
+  candidate: WeaveableKnopCandidate,
+): WeavePlan {
+  const referenceCatalogArtifact = candidate.referenceCatalogArtifact!;
+  assertCurrentMeshInventoryShapeForFirstReferenceCatalogWeave(
+    currentMeshInventoryTurtle,
+  );
+  assertCurrentKnopInventoryShapeForFirstReferenceCatalogWeave(
+    candidate.currentKnopInventoryTurtle,
+    candidate.designatorPath,
+    referenceCatalogArtifact.workingFilePath,
+  );
+
+  const designatorPath = candidate.designatorPath;
+  const knopPath = toKnopPath(designatorPath);
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const referenceCatalogLinks = extractCurrentReferenceCatalogLinks(
+    referenceCatalogArtifact.currentReferenceCatalogTurtle,
+    designatorPath,
+    referenceCatalogPath,
+  );
+
+  return {
+    meshBase,
+    wovenDesignatorPaths: [designatorPath],
+    createdFiles: [
+      {
+        path:
+          `${knopPath}/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl`,
+        contents: renderFirstReferenceCatalogWovenKnopInventoryTurtle(
+          meshBase,
+          designatorPath,
+        ),
+      },
+      {
+        path:
+          `${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl`,
+        contents: referenceCatalogArtifact.currentReferenceCatalogTurtle,
+      },
+    ],
+    updatedFiles: [
+      {
+        path: `${knopPath}/_inventory/inventory.ttl`,
+        contents: renderFirstReferenceCatalogWovenKnopInventoryTurtle(
+          meshBase,
+          designatorPath,
+        ),
+      },
+    ],
+    createdPages: buildFirstReferenceCatalogWeavePages(
+      designatorPath,
+      referenceCatalogLinks,
+    ),
+  };
+}
+
 function assertCurrentMeshInventoryShapeForFirstKnopWeave(
   currentMeshInventoryTurtle: string,
 ): void {
@@ -353,6 +491,27 @@ function assertCurrentMeshInventoryShapeForFirstPayloadWeave(
   }
 }
 
+function assertCurrentMeshInventoryShapeForFirstReferenceCatalogWeave(
+  currentMeshInventoryTurtle: string,
+): void {
+  const requiredFragments = [
+    "<_mesh/_inventory> a sflo:MeshInventory, sflo:DigitalArtifact, sflo:RdfDocument ;",
+    "sflo:currentArtifactHistory <_mesh/_inventory/_history001> ;",
+    "sflo:latestHistoricalState <_mesh/_inventory/_history001/_s0003> ;",
+    'sflo:nextStateOrdinal "4"^^xsd:nonNegativeInteger ;',
+    "<alice/_knop> a sflo:Knop ;",
+    "<alice/bio/_knop> a sflo:Knop ;",
+  ];
+
+  for (const fragment of requiredFragments) {
+    if (!currentMeshInventoryTurtle.includes(fragment)) {
+      throw new WeaveInputError(
+        "The current local weave slice only supports the settled 08 pre-weave reference-catalog mesh inventory shape.",
+      );
+    }
+  }
+}
+
 function assertCurrentKnopMetadataShape(
   currentKnopMetadataTurtle: string,
   designatorPath: string,
@@ -379,7 +538,7 @@ function assertCurrentKnopMetadataShape(
   }
 }
 
-function assertCurrentKnopInventoryShape(
+function assertCurrentKnopInventoryBaseShape(
   currentKnopInventoryTurtle: string,
   knopPath: string,
 ): void {
@@ -397,7 +556,12 @@ function assertCurrentKnopInventoryShape(
       );
     }
   }
+}
 
+function assertCurrentKnopInventoryWithoutHistory(
+  currentKnopInventoryTurtle: string,
+  knopPath: string,
+): void {
   if (currentKnopInventoryTurtle.includes("sflo:hasArtifactHistory")) {
     throw new WeaveInputError(
       `KnopInventory already has explicit history for ${knopPath}.`,
@@ -432,6 +596,96 @@ function assertCurrentPayloadArtifactShape(
       `Payload artifact already has explicit history for ${designatorPath}.`,
     );
   }
+}
+
+function assertCurrentKnopInventoryShapeForFirstReferenceCatalogWeave(
+  currentKnopInventoryTurtle: string,
+  designatorPath: string,
+  workingFilePath: string,
+): void {
+  const knopPath = toKnopPath(designatorPath);
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const requiredFragments = [
+    `<${knopPath}> a sflo:Knop ;`,
+    `sflo:hasReferenceCatalog <${referenceCatalogPath}> ;`,
+    `<${knopPath}/_inventory> a sflo:KnopInventory, sflo:DigitalArtifact, sflo:RdfDocument ;`,
+    `sflo:currentArtifactHistory <${knopPath}/_inventory/_history001> ;`,
+    `sflo:latestHistoricalState <${knopPath}/_inventory/_history001/_s0001> ;`,
+    'sflo:nextStateOrdinal "2"^^xsd:nonNegativeInteger ;',
+    `<${referenceCatalogPath}> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;`,
+    `sflo:hasWorkingLocatedFile <${workingFilePath}> .`,
+  ];
+
+  for (const fragment of requiredFragments) {
+    if (!currentKnopInventoryTurtle.includes(fragment)) {
+      throw new WeaveInputError(
+        `The current local weave slice only supports the settled first ReferenceCatalog weave shape for ${designatorPath}.`,
+      );
+    }
+  }
+
+  if (
+    currentKnopInventoryTurtle.includes(
+      `sflo:hasArtifactHistory <${referenceCatalogPath}/_history001>`,
+    )
+  ) {
+    throw new WeaveInputError(
+      `ReferenceCatalog already has explicit history for ${designatorPath}.`,
+    );
+  }
+}
+
+function extractCurrentReferenceCatalogLinks(
+  currentReferenceCatalogTurtle: string,
+  designatorPath: string,
+  referenceCatalogPath: string,
+): readonly ReferenceCatalogCurrentLinkModel[] {
+  const blocks = currentReferenceCatalogTurtle
+    .split("\n\n")
+    .map((block) => block.trim())
+    .filter((block) => block.startsWith(`<${referenceCatalogPath}#`));
+  const links: ReferenceCatalogCurrentLinkModel[] = [];
+
+  for (const block of blocks) {
+    const fragmentMatch = block.match(
+      new RegExp(
+        `^<${
+          escapeForRegExp(referenceCatalogPath)
+        }#([^>]+)> a sflo:ReferenceLink ;`,
+      ),
+    );
+    const linkForMatch = block.match(/sflo:referenceLinkFor <([^>]+)> ;/);
+    const roleMatch = block.match(/sflo:hasReferenceRole <([^>]+)> ;/);
+    const targetMatch = block.match(/sflo:referenceTarget <([^>]+)> \.$/m);
+
+    if (!fragmentMatch || !linkForMatch || !roleMatch || !targetMatch) {
+      throw new WeaveInputError(
+        `Could not parse the current ReferenceCatalog working file for ${designatorPath}.`,
+      );
+    }
+
+    if (linkForMatch[1] !== designatorPath) {
+      throw new WeaveInputError(
+        `ReferenceCatalog link target subject did not match ${designatorPath}.`,
+      );
+    }
+
+    links.push({
+      fragment: fragmentMatch[1]!,
+      referenceRoleLabel: toReferenceRoleLabel(roleMatch[1]!),
+      referenceTargetPath: targetMatch[1]!,
+    });
+  }
+
+  if (links.length === 0) {
+    throw new WeaveInputError(
+      `ReferenceCatalog working file did not contain any current links for ${designatorPath}.`,
+    );
+  }
+
+  return links.sort((left, right) =>
+    left.fragment.localeCompare(right.fragment)
+  );
 }
 
 function renderFirstKnopWovenMeshInventoryTurtle(
@@ -947,6 +1201,154 @@ function renderFirstPayloadWovenKnopInventoryTurtle(
 `;
 }
 
+function renderFirstReferenceCatalogWovenKnopInventoryTurtle(
+  meshBase: string,
+  designatorPath: string,
+): string {
+  const knopPath = toKnopPath(designatorPath);
+  const referenceCatalogPath = `${knopPath}/_references`;
+
+  return `@base <${meshBase}> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<${knopPath}> a sflo:Knop ;
+  sflo:hasKnopMetadata <${knopPath}/_meta> ;
+  sflo:hasKnopInventory <${knopPath}/_inventory> ;
+  sflo:hasWorkingKnopInventoryFile <${knopPath}/_inventory/inventory.ttl> ;
+  sflo:hasReferenceCatalog <${referenceCatalogPath}> ;
+  sflo:hasResourcePage <${knopPath}/index.html> .
+
+<${knopPath}/_meta> a sflo:KnopMetadata, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <${knopPath}/_meta/_history001> ;
+  sflo:currentArtifactHistory <${knopPath}/_meta/_history001> ;
+  sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasWorkingLocatedFile <${knopPath}/_meta/meta.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_meta/index.html> .
+
+<${knopPath}/_meta/_history001> a sflo:ArtifactHistory ;
+  sflo:historyOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasHistoricalState <${knopPath}/_meta/_history001/_s0001> ;
+  sflo:latestHistoricalState <${knopPath}/_meta/_history001/_s0001> ;
+  sflo:nextStateOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasResourcePage <${knopPath}/_meta/_history001/index.html> .
+
+<${knopPath}/_meta/_history001/_s0001> a sflo:HistoricalState ;
+  sflo:stateOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasManifestation <${knopPath}/_meta/_history001/_s0001/meta-ttl> ;
+  sflo:locatedFileForState <${knopPath}/_meta/_history001/_s0001/meta-ttl/meta.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_meta/_history001/_s0001/index.html> .
+
+<${knopPath}/_meta/_history001/_s0001/meta-ttl> a sflo:ArtifactManifestation, sflo:RdfDocument ;
+  sflo:hasLocatedFile <${knopPath}/_meta/_history001/_s0001/meta-ttl/meta.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_meta/_history001/_s0001/meta-ttl/index.html> .
+
+<${knopPath}/_inventory> a sflo:KnopInventory, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <${knopPath}/_inventory/_history001> ;
+  sflo:currentArtifactHistory <${knopPath}/_inventory/_history001> ;
+  sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasWorkingLocatedFile <${knopPath}/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_inventory/index.html> .
+
+<${referenceCatalogPath}> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <${referenceCatalogPath}/_history001> ;
+  sflo:currentArtifactHistory <${referenceCatalogPath}/_history001> ;
+  sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasWorkingLocatedFile <${referenceCatalogPath}/references.ttl> ;
+  sflo:hasResourcePage <${referenceCatalogPath}/index.html> .
+
+<${knopPath}/_inventory/_history001> a sflo:ArtifactHistory ;
+  sflo:historyOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasHistoricalState <${knopPath}/_inventory/_history001/_s0001> ;
+  sflo:hasHistoricalState <${knopPath}/_inventory/_history001/_s0002> ;
+  sflo:latestHistoricalState <${knopPath}/_inventory/_history001/_s0002> ;
+  sflo:nextStateOrdinal "3"^^xsd:nonNegativeInteger ;
+  sflo:hasResourcePage <${knopPath}/_inventory/_history001/index.html> .
+
+<${knopPath}/_inventory/_history001/_s0001> a sflo:HistoricalState ;
+  sflo:stateOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasManifestation <${knopPath}/_inventory/_history001/_s0001/inventory-ttl> ;
+  sflo:locatedFileForState <${knopPath}/_inventory/_history001/_s0001/inventory-ttl/inventory.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_inventory/_history001/_s0001/index.html> .
+
+<${knopPath}/_inventory/_history001/_s0001/inventory-ttl> a sflo:ArtifactManifestation, sflo:RdfDocument ;
+  sflo:hasLocatedFile <${knopPath}/_inventory/_history001/_s0001/inventory-ttl/inventory.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_inventory/_history001/_s0001/inventory-ttl/index.html> .
+
+<${knopPath}/_inventory/_history001/_s0002> a sflo:HistoricalState ;
+  sflo:stateOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:previousHistoricalState <${knopPath}/_inventory/_history001/_s0001> ;
+  sflo:hasManifestation <${knopPath}/_inventory/_history001/_s0002/inventory-ttl> ;
+  sflo:locatedFileForState <${knopPath}/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_inventory/_history001/_s0002/index.html> .
+
+<${knopPath}/_inventory/_history001/_s0002/inventory-ttl> a sflo:ArtifactManifestation, sflo:RdfDocument ;
+  sflo:hasLocatedFile <${knopPath}/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl> ;
+  sflo:hasResourcePage <${knopPath}/_inventory/_history001/_s0002/inventory-ttl/index.html> .
+
+<${referenceCatalogPath}/_history001> a sflo:ArtifactHistory ;
+  sflo:historyOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasHistoricalState <${referenceCatalogPath}/_history001/_s0001> ;
+  sflo:latestHistoricalState <${referenceCatalogPath}/_history001/_s0001> ;
+  sflo:nextStateOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasResourcePage <${referenceCatalogPath}/_history001/index.html> .
+
+<${referenceCatalogPath}/_history001/_s0001> a sflo:HistoricalState ;
+  sflo:stateOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasManifestation <${referenceCatalogPath}/_history001/_s0001/references-ttl> ;
+  sflo:locatedFileForState <${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl> ;
+  sflo:hasResourcePage <${referenceCatalogPath}/_history001/_s0001/index.html> .
+
+<${referenceCatalogPath}/_history001/_s0001/references-ttl> a sflo:ArtifactManifestation, sflo:RdfDocument ;
+  sflo:hasLocatedFile <${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl> ;
+  sflo:hasResourcePage <${referenceCatalogPath}/_history001/_s0001/references-ttl/index.html> .
+
+<${knopPath}/_meta/meta.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<${knopPath}/_inventory/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<${referenceCatalogPath}/references.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<${knopPath}/_meta/_history001/_s0001/meta-ttl/meta.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<${knopPath}/_inventory/_history001/_s0001/inventory-ttl/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<${knopPath}/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<${referenceCatalogPath}/_history001/_s0001/references-ttl/references.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+<${knopPath}/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_meta/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_meta/_history001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_meta/_history001/_s0001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_meta/_history001/_s0001/meta-ttl/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_inventory/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_inventory/_history001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_inventory/_history001/_s0001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_inventory/_history001/_s0001/inventory-ttl/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_inventory/_history001/_s0002/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${knopPath}/_inventory/_history001/_s0002/inventory-ttl/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${referenceCatalogPath}/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${referenceCatalogPath}/_history001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${referenceCatalogPath}/_history001/_s0001/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<${referenceCatalogPath}/_history001/_s0001/references-ttl/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+`;
+}
+
 function buildFirstKnopWeavePages(
   designatorPath: string,
 ): readonly ResourcePageModel[] {
@@ -1076,6 +1478,43 @@ function buildFirstPayloadWeavePages(
   ];
 }
 
+function buildFirstReferenceCatalogWeavePages(
+  designatorPath: string,
+  currentLinks: readonly ReferenceCatalogCurrentLinkModel[],
+): readonly ResourcePageModel[] {
+  const knopPath = toKnopPath(designatorPath);
+  const referenceCatalogPath = `${knopPath}/_references`;
+
+  return [
+    simplePage(
+      `${knopPath}/_inventory/_history001/_s0002/index.html`,
+      `Resource page for the second ${designatorPath} KnopInventory historical state.`,
+    ),
+    simplePage(
+      `${knopPath}/_inventory/_history001/_s0002/inventory-ttl/index.html`,
+      `Resource page for the Turtle manifestation of the second ${designatorPath} KnopInventory historical state.`,
+    ),
+    referenceCatalogPage(
+      `${referenceCatalogPath}/index.html`,
+      referenceCatalogPath,
+      designatorPath,
+      currentLinks,
+    ),
+    simplePage(
+      `${referenceCatalogPath}/_history001/index.html`,
+      `Resource page for the current explicit history of the ${designatorPath} ReferenceCatalog artifact.`,
+    ),
+    simplePage(
+      `${referenceCatalogPath}/_history001/_s0001/index.html`,
+      `Resource page for the first ${designatorPath} ReferenceCatalog historical state.`,
+    ),
+    simplePage(
+      `${referenceCatalogPath}/_history001/_s0001/references-ttl/index.html`,
+      `Resource page for the Turtle manifestation of the first ${designatorPath} ReferenceCatalog historical state.`,
+    ),
+  ];
+}
+
 function identifierPage(
   path: string,
   designatorPath: string,
@@ -1100,6 +1539,21 @@ function simplePage(
   };
 }
 
+function referenceCatalogPage(
+  path: string,
+  catalogPath: string,
+  ownerDesignatorPath: string,
+  currentLinks: readonly ReferenceCatalogCurrentLinkModel[],
+): ReferenceCatalogResourcePageModel {
+  return {
+    kind: "referenceCatalog",
+    path,
+    catalogPath,
+    ownerDesignatorPath,
+    currentLinks,
+  };
+}
+
 function toPayloadManifestationPath(
   designatorPath: string,
   workingFilePath: string,
@@ -1116,6 +1570,15 @@ function toManifestationSegment(workingFilePath: string): string {
 function toFileName(path: string): string {
   const segments = path.split("/");
   return segments[segments.length - 1]!;
+}
+
+function toReferenceRoleLabel(referenceRoleIri: string): string {
+  const segments = referenceRoleIri.split("/");
+  return (segments[segments.length - 1] ?? referenceRoleIri).toLowerCase();
+}
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function toKnopPath(designatorPath: string): string {

--- a/src/core/weave/weave.ts
+++ b/src/core/weave/weave.ts
@@ -133,11 +133,11 @@ export function planWeave(input: PlanWeaveInput): WeavePlan {
         input.currentMeshInventoryTurtle,
         candidate,
       );
+    default:
+      throw new WeaveInputError(
+        `No supported local weave slice was found for ${designatorPath}.`,
+      );
   }
-
-  throw new WeaveInputError(
-    `No supported local weave slice was found for ${designatorPath}.`,
-  );
 }
 
 function normalizeMeshBase(meshBase: string): string {
@@ -410,8 +410,10 @@ function planFirstReferenceCatalogWeave(
   candidate: WeaveableKnopCandidate,
 ): WeavePlan {
   const referenceCatalogArtifact = candidate.referenceCatalogArtifact!;
+  const designatorPath = candidate.designatorPath;
   assertCurrentMeshInventoryShapeForFirstReferenceCatalogWeave(
     currentMeshInventoryTurtle,
+    designatorPath,
   );
   assertCurrentKnopInventoryShapeForFirstReferenceCatalogWeave(
     candidate.currentKnopInventoryTurtle,
@@ -419,7 +421,6 @@ function planFirstReferenceCatalogWeave(
     referenceCatalogArtifact.workingFilePath,
   );
 
-  const designatorPath = candidate.designatorPath;
   const knopPath = toKnopPath(designatorPath);
   const referenceCatalogPath = `${knopPath}/_references`;
   const referenceCatalogWorkingFilePath = referenceCatalogArtifact
@@ -516,14 +517,15 @@ function assertCurrentMeshInventoryShapeForFirstPayloadWeave(
 
 function assertCurrentMeshInventoryShapeForFirstReferenceCatalogWeave(
   currentMeshInventoryTurtle: string,
+  designatorPath: string,
 ): void {
+  const knopPath = toKnopPath(designatorPath);
   const requiredFragments = [
     "<_mesh/_inventory> a sflo:MeshInventory, sflo:DigitalArtifact, sflo:RdfDocument ;",
     "sflo:currentArtifactHistory <_mesh/_inventory/_history001> ;",
     "sflo:latestHistoricalState <_mesh/_inventory/_history001/_s0003> ;",
     'sflo:nextStateOrdinal "4"^^xsd:nonNegativeInteger ;',
-    "<alice/_knop> a sflo:Knop ;",
-    "<alice/bio/_knop> a sflo:Knop ;",
+    `<${knopPath}> a sflo:Knop ;`,
   ];
 
   for (const fragment of requiredFragments) {

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -316,6 +316,55 @@ Deno.test("planWeave renders the first alice reference-catalog weave slice", () 
   );
 });
 
+Deno.test("planWeave preserves the current ReferenceCatalog working file path", () => {
+  const workingFilePath = "alice/_knop/_references/reference-links-v1.ttl";
+  const plan = planWeave({
+    request: {},
+    meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+    currentMeshInventoryTurtle: firstReferenceCatalogWeaveMeshInventoryTurtle,
+    weaveableKnops: [{
+      designatorPath: "alice",
+      currentKnopMetadataTurtle: firstWeaveKnopMetadataTurtle,
+      currentKnopInventoryTurtle: firstReferenceCatalogWeaveKnopInventoryTurtle
+        .replaceAll(
+          "alice/_knop/_references/references.ttl",
+          workingFilePath,
+        ),
+      referenceCatalogArtifact: {
+        workingFilePath,
+        currentReferenceCatalogTurtle:
+          firstReferenceCatalogWeaveReferenceCatalogTurtle,
+      },
+    }],
+  });
+
+  assertEquals(
+    plan.createdFiles.map((file) => file.path),
+    [
+      "alice/_knop/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl",
+      "alice/_knop/_references/_history001/_s0001/reference-links-v1-ttl/reference-links-v1.ttl",
+    ],
+  );
+  assertStringIncludes(
+    plan.updatedFiles[0]?.contents ?? "",
+    `sflo:hasWorkingLocatedFile <${workingFilePath}> ;`,
+  );
+  assertStringIncludes(
+    plan.updatedFiles[0]?.contents ?? "",
+    "sflo:locatedFileForState <alice/_knop/_references/_history001/_s0001/reference-links-v1-ttl/reference-links-v1.ttl> ;",
+  );
+  assertEquals(
+    plan.createdPages[5],
+    {
+      kind: "simple",
+      path:
+        "alice/_knop/_references/_history001/_s0001/reference-links-v1-ttl/index.html",
+      description:
+        "Resource page for the Turtle manifestation of the first alice ReferenceCatalog historical state.",
+    },
+  );
+});
+
 Deno.test("planWeave rejects when no weaveable candidates were provided", () => {
   assertThrows(
     () =>

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -100,6 +100,79 @@ const firstPayloadWeaveKnopInventoryTurtle =
   sflo:hasWorkingLocatedFile <alice-bio.ttl> .
 `;
 
+const firstReferenceCatalogWeaveMeshInventoryTurtle =
+  `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<_mesh/_inventory> a sflo:MeshInventory, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <_mesh/_inventory/_history001> ;
+  sflo:currentArtifactHistory <_mesh/_inventory/_history001> ;
+  sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasWorkingLocatedFile <_mesh/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <_mesh/_inventory/index.html> .
+
+<_mesh/_inventory/_history001> a sflo:ArtifactHistory ;
+  sflo:historyOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasHistoricalState <_mesh/_inventory/_history001/_s0001> ;
+  sflo:hasHistoricalState <_mesh/_inventory/_history001/_s0002> ;
+  sflo:hasHistoricalState <_mesh/_inventory/_history001/_s0003> ;
+  sflo:latestHistoricalState <_mesh/_inventory/_history001/_s0003> ;
+  sflo:nextStateOrdinal "4"^^xsd:nonNegativeInteger ;
+  sflo:hasResourcePage <_mesh/_inventory/_history001/index.html> .
+
+<alice/_knop> a sflo:Knop ;
+  sflo:hasWorkingKnopInventoryFile <alice/_knop/_inventory/inventory.ttl> .
+
+<alice/bio> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <alice-bio.ttl> .
+
+<alice/bio/_knop> a sflo:Knop ;
+  sflo:hasWorkingKnopInventoryFile <alice/bio/_knop/_inventory/inventory.ttl> .
+`;
+
+const firstReferenceCatalogWeaveKnopInventoryTurtle =
+  `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<alice/_knop> a sflo:Knop ;
+  sflo:hasKnopMetadata <alice/_knop/_meta> ;
+  sflo:hasKnopInventory <alice/_knop/_inventory> ;
+  sflo:hasWorkingKnopInventoryFile <alice/_knop/_inventory/inventory.ttl> ;
+  sflo:hasReferenceCatalog <alice/_knop/_references> ;
+  sflo:hasResourcePage <alice/_knop/index.html> .
+
+<alice/_knop/_inventory> a sflo:KnopInventory, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <alice/_knop/_inventory/_history001> ;
+  sflo:currentArtifactHistory <alice/_knop/_inventory/_history001> ;
+  sflo:nextHistoryOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasWorkingLocatedFile <alice/_knop/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <alice/_knop/_inventory/index.html> .
+
+<alice/_knop/_references> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <alice/_knop/_references/references.ttl> .
+
+<alice/_knop/_inventory/_history001> a sflo:ArtifactHistory ;
+  sflo:historyOrdinal "1"^^xsd:nonNegativeInteger ;
+  sflo:hasHistoricalState <alice/_knop/_inventory/_history001/_s0001> ;
+  sflo:latestHistoricalState <alice/_knop/_inventory/_history001/_s0001> ;
+  sflo:nextStateOrdinal "2"^^xsd:nonNegativeInteger ;
+  sflo:hasResourcePage <alice/_knop/_inventory/_history001/index.html> .
+`;
+
+const firstReferenceCatalogWeaveReferenceCatalogTurtle =
+  `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+
+<alice> sflo:hasReferenceLink <alice/_knop/_references#reference001> .
+
+<alice/_knop/_references#reference001> a sflo:ReferenceLink ;
+  sflo:referenceLinkFor <alice> ;
+  sflo:hasReferenceRole <https://semantic-flow.github.io/semantic-flow-ontology/ReferenceRole/Canonical> ;
+  sflo:referenceTarget <alice/bio> .
+`;
+
 Deno.test("planWeave renders the first alice knop-created-woven slice", () => {
   const plan = planWeave({
     request: {},
@@ -191,6 +264,55 @@ Deno.test("planWeave renders the first alice bio payload weave slice", () => {
   assertStringIncludes(
     plan.updatedFiles[1]?.contents ?? "",
     "sflo:currentArtifactHistory <alice/bio/_history001> ;",
+  );
+});
+
+Deno.test("planWeave renders the first alice reference-catalog weave slice", () => {
+  const plan = planWeave({
+    request: {},
+    meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+    currentMeshInventoryTurtle: firstReferenceCatalogWeaveMeshInventoryTurtle,
+    weaveableKnops: [{
+      designatorPath: "alice",
+      currentKnopMetadataTurtle: firstWeaveKnopMetadataTurtle,
+      currentKnopInventoryTurtle: firstReferenceCatalogWeaveKnopInventoryTurtle,
+      referenceCatalogArtifact: {
+        workingFilePath: "alice/_knop/_references/references.ttl",
+        currentReferenceCatalogTurtle:
+          firstReferenceCatalogWeaveReferenceCatalogTurtle,
+      },
+    }],
+  });
+
+  assertEquals(plan.wovenDesignatorPaths, ["alice"]);
+  assertEquals(plan.updatedFiles.map((file) => file.path), [
+    "alice/_knop/_inventory/inventory.ttl",
+  ]);
+  assertEquals(
+    plan.createdFiles.map((file) => file.path),
+    [
+      "alice/_knop/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl",
+      "alice/_knop/_references/_history001/_s0001/references-ttl/references.ttl",
+    ],
+  );
+  assertEquals(plan.createdPages[2], {
+    kind: "referenceCatalog",
+    path: "alice/_knop/_references/index.html",
+    catalogPath: "alice/_knop/_references",
+    ownerDesignatorPath: "alice",
+    currentLinks: [{
+      fragment: "reference001",
+      referenceRoleLabel: "canonical",
+      referenceTargetPath: "alice/bio",
+    }],
+  });
+  assertStringIncludes(
+    plan.updatedFiles[0]?.contents ?? "",
+    "sflo:latestHistoricalState <alice/_knop/_inventory/_history001/_s0002> ;",
+  );
+  assertStringIncludes(
+    plan.updatedFiles[0]?.contents ?? "",
+    "sflo:hasArtifactHistory <alice/_knop/_references/_history001> ;",
   );
 });
 

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -365,6 +365,41 @@ Deno.test("planWeave preserves the current ReferenceCatalog working file path", 
   );
 });
 
+Deno.test("planWeave supports the first reference-catalog weave slice for non-alice designators", () => {
+  const plan = planWeave({
+    request: {},
+    meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+    currentMeshInventoryTurtle: firstReferenceCatalogWeaveMeshInventoryTurtle
+      .replaceAll("alice/bio", "carol/bio")
+      .replaceAll("alice", "carol"),
+    weaveableKnops: [{
+      designatorPath: "carol",
+      currentKnopMetadataTurtle: firstWeaveKnopMetadataTurtle.replaceAll(
+        "alice",
+        "carol",
+      ),
+      currentKnopInventoryTurtle: firstReferenceCatalogWeaveKnopInventoryTurtle
+        .replaceAll("alice", "carol"),
+      referenceCatalogArtifact: {
+        workingFilePath: "carol/_knop/_references/references.ttl",
+        currentReferenceCatalogTurtle:
+          firstReferenceCatalogWeaveReferenceCatalogTurtle
+            .replaceAll("alice/bio", "carol/bio")
+            .replaceAll("alice", "carol"),
+      },
+    }],
+  });
+
+  assertEquals(plan.wovenDesignatorPaths, ["carol"]);
+  assertEquals(plan.updatedFiles.map((file) => file.path), [
+    "carol/_knop/_inventory/inventory.ttl",
+  ]);
+  assertEquals(
+    plan.createdFiles[1]?.path,
+    "carol/_knop/_references/_history001/_s0001/references-ttl/references.ttl",
+  );
+});
+
 Deno.test("planWeave rejects when no weaveable candidates were provided", () => {
   assertThrows(
     () =>

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -2,4 +2,5 @@ export * from "./logging/mod.ts";
 export * from "./integrate/mod.ts";
 export * from "./knop/mod.ts";
 export * from "./mesh/mod.ts";
+export * from "./payload/mod.ts";
 export * from "./weave/mod.ts";

--- a/src/runtime/payload/mod.ts
+++ b/src/runtime/payload/mod.ts
@@ -1,0 +1,1 @@
+export * from "./update.ts";

--- a/src/runtime/payload/update.ts
+++ b/src/runtime/payload/update.ts
@@ -290,25 +290,26 @@ async function resolveReplacementSource(
 }
 
 function resolveSourcePath(workspaceRoot: string, source: string): string {
-  const parsedUrl = tryParseUrl(source);
-  if (parsedUrl) {
-    if (parsedUrl.protocol !== "file:") {
+  if (source.startsWith("file:")) {
+    let fileUrl: URL;
+    try {
+      fileUrl = new URL(source);
+    } catch {
       throw new PayloadUpdateRuntimeError(
-        "The current local payload update slice only supports local filesystem sources.",
+        `payload update source is not a valid file URL: ${source}`,
       );
     }
-    return resolve(fromFileUrl(parsedUrl));
+
+    return resolve(fromFileUrl(fileUrl));
+  }
+
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(source)) {
+    throw new PayloadUpdateRuntimeError(
+      "The current local payload update slice only supports local filesystem sources.",
+    );
   }
 
   return isAbsolute(source) ? resolve(source) : resolve(workspaceRoot, source);
-}
-
-function tryParseUrl(value: string): URL | undefined {
-  try {
-    return new URL(value);
-  } catch {
-    return undefined;
-  }
 }
 
 async function loadCurrentPayloadState(

--- a/src/runtime/payload/update.ts
+++ b/src/runtime/payload/update.ts
@@ -1,5 +1,6 @@
 import { dirname, fromFileUrl, isAbsolute, join, resolve } from "@std/path";
 import { Parser } from "n3";
+import { RESERVED_DESIGNATOR_SEGMENTS } from "../../core/designator_segments.ts";
 import {
   PayloadUpdateInputError,
   type PayloadUpdatePlan,
@@ -9,7 +10,6 @@ import { resolveRuntimeLoggers } from "../logging/factory.ts";
 import type { AuditLogger } from "../logging/audit_logger.ts";
 import type { StructuredLogger } from "../logging/logger.ts";
 
-const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
 const safeDesignatorSegmentPattern = /^[A-Za-z0-9._-]+$/;
 
 export interface LocalPayloadUpdateRequest {
@@ -94,7 +94,7 @@ export async function executePayloadUpdate(
       workingFilePath: payloadState.workingFilePath,
       replacementPayloadTurtle: resolvedSource.replacementPayloadTurtle,
     });
-    assertUpdatedTargetsExist(workspaceRoot, plan);
+    await assertUpdatedTargetsExist(workspaceRoot, plan);
     validateRdfPlan(plan);
     await applyPayloadUpdateAtomically(workspaceRoot, plan);
   } catch (error) {
@@ -170,7 +170,10 @@ export async function executePayloadUpdate(
 export function describePayloadUpdateResult(
   result: PayloadUpdateResult,
 ): string {
-  return `Updated payload ${result.payloadArtifactIri} by replacing ${result.workingFilePath} and updating ${result.updatedPaths.length} working file.`;
+  const updatedFileCount = result.updatedPaths.length;
+  const updatedFileLabel = updatedFileCount === 1 ? "file" : "files";
+
+  return `Updated payload ${result.payloadArtifactIri} by replacing working file ${result.workingFilePath} (updated ${updatedFileCount} ${updatedFileLabel}).`;
 }
 
 function resolveLoggers(
@@ -234,7 +237,7 @@ function normalizeLocalDesignatorPath(
       `${fieldName} must not contain '.' or '..' path segments`,
     );
   }
-  if (segments.some((segment) => reservedDesignatorSegments.has(segment))) {
+  if (segments.some((segment) => RESERVED_DESIGNATOR_SEGMENTS.has(segment))) {
     throw new PayloadUpdateRuntimeError(
       `${fieldName} must not contain reserved path segments`,
     );
@@ -393,14 +396,14 @@ async function loadCurrentPayloadState(
   };
 }
 
-function assertUpdatedTargetsExist(
+async function assertUpdatedTargetsExist(
   workspaceRoot: string,
   plan: PayloadUpdatePlan,
-): void {
+): Promise<void> {
   for (const file of plan.updatedFiles) {
     const absolutePath = join(workspaceRoot, file.path);
     try {
-      Deno.statSync(absolutePath);
+      await Deno.stat(absolutePath);
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) {
         throw new PayloadUpdateRuntimeError(
@@ -434,6 +437,12 @@ async function applyPayloadUpdateAtomically(
   workspaceRoot: string,
   plan: PayloadUpdatePlan,
 ): Promise<void> {
+  if (plan.updatedFiles.length !== 1) {
+    throw new PayloadUpdateRuntimeError(
+      `The current local payload update slice expected exactly one updated working file, found ${plan.updatedFiles.length}.`,
+    );
+  }
+
   const file = plan.updatedFiles[0]!;
   const absolutePath = join(workspaceRoot, file.path);
   const directoryPath = dirname(absolutePath);

--- a/src/runtime/payload/update.ts
+++ b/src/runtime/payload/update.ts
@@ -1,0 +1,503 @@
+import { dirname, fromFileUrl, isAbsolute, join, resolve } from "@std/path";
+import { Parser } from "n3";
+import {
+  PayloadUpdateInputError,
+  type PayloadUpdatePlan,
+  planPayloadUpdate,
+} from "../../core/payload/update.ts";
+import { resolveRuntimeLoggers } from "../logging/factory.ts";
+import type { AuditLogger } from "../logging/audit_logger.ts";
+import type { StructuredLogger } from "../logging/logger.ts";
+
+const reservedDesignatorSegments = new Set(["_knop", "_mesh"]);
+const safeDesignatorSegmentPattern = /^[A-Za-z0-9._-]+$/;
+
+export interface LocalPayloadUpdateRequest {
+  designatorPath: string;
+  source: string;
+}
+
+export interface ExecutePayloadUpdateOptions {
+  workspaceRoot: string;
+  request: LocalPayloadUpdateRequest;
+  operationalLogger?: StructuredLogger;
+  auditLogger?: AuditLogger;
+}
+
+export interface PayloadUpdateResult {
+  meshBase: string;
+  designatorPath: string;
+  payloadArtifactIri: string;
+  workingFilePath: string;
+  updatedPaths: readonly string[];
+}
+
+export class PayloadUpdateRuntimeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PayloadUpdateRuntimeError";
+  }
+}
+
+interface StagedPayloadUpdate {
+  absolutePath: string;
+  tempPath: string;
+  backupPath: string;
+}
+
+export async function executePayloadUpdate(
+  options: ExecutePayloadUpdateOptions,
+): Promise<PayloadUpdateResult> {
+  const { operationalLogger, auditLogger } = resolveLoggers(options);
+  const workspaceRoot = options.workspaceRoot;
+  const source = options.request.source;
+  const designatorPath = options.request.designatorPath;
+  let plan: PayloadUpdatePlan | undefined;
+
+  await operationalLogger.info(
+    "payload.update.started",
+    "Starting local payload update",
+    {
+      workspaceRoot,
+      designatorPath,
+      source,
+    },
+  );
+  await auditLogger.record(
+    "payload.update.started",
+    "Local payload update started",
+    {
+      workspaceRoot,
+      designatorPath,
+      source,
+    },
+  );
+
+  try {
+    await ensureWorkspaceRootExists(workspaceRoot);
+    const normalizedDesignatorPath = normalizeLocalDesignatorPath(
+      designatorPath,
+      "designatorPath",
+    );
+    const resolvedSource = await resolveReplacementSource(
+      workspaceRoot,
+      source,
+    );
+    const payloadState = await loadCurrentPayloadState(
+      workspaceRoot,
+      normalizedDesignatorPath,
+    );
+    plan = planPayloadUpdate({
+      meshBase: payloadState.meshBase,
+      currentKnopInventoryTurtle: payloadState.currentKnopInventoryTurtle,
+      designatorPath: normalizedDesignatorPath,
+      workingFilePath: payloadState.workingFilePath,
+      replacementPayloadTurtle: resolvedSource.replacementPayloadTurtle,
+    });
+    assertUpdatedTargetsExist(workspaceRoot, plan);
+    validateRdfPlan(plan);
+    await applyPayloadUpdateAtomically(workspaceRoot, plan);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await operationalLogger.error(
+      "payload.update.failed",
+      "Local payload update failed",
+      {
+        workspaceRoot,
+        designatorPath,
+        source,
+        payloadArtifactIri: plan?.payloadArtifactIri,
+        workingFilePath: plan?.workingFilePath,
+        error: message,
+      },
+    );
+    await auditLogger.record(
+      "payload.update.failed",
+      "Local payload update failed",
+      {
+        workspaceRoot,
+        designatorPath,
+        source,
+        payloadArtifactIri: plan?.payloadArtifactIri,
+        workingFilePath: plan?.workingFilePath,
+        error: message,
+      },
+    );
+
+    if (
+      error instanceof PayloadUpdateInputError ||
+      error instanceof PayloadUpdateRuntimeError
+    ) {
+      throw error;
+    }
+    throw new PayloadUpdateRuntimeError(message);
+  }
+
+  const result: PayloadUpdateResult = {
+    meshBase: plan.meshBase,
+    designatorPath: plan.designatorPath,
+    payloadArtifactIri: plan.payloadArtifactIri,
+    workingFilePath: plan.workingFilePath,
+    updatedPaths: plan.updatedFiles.map((file) => file.path),
+  };
+
+  await operationalLogger.info(
+    "payload.update.succeeded",
+    "Local payload update succeeded",
+    {
+      workspaceRoot,
+      designatorPath: result.designatorPath,
+      payloadArtifactIri: result.payloadArtifactIri,
+      workingFilePath: result.workingFilePath,
+      updatedPaths: result.updatedPaths,
+    },
+  );
+  await auditLogger.record(
+    "payload.update.succeeded",
+    "Local payload update succeeded",
+    {
+      workspaceRoot,
+      designatorPath: result.designatorPath,
+      payloadArtifactIri: result.payloadArtifactIri,
+      workingFilePath: result.workingFilePath,
+      updatedPaths: result.updatedPaths,
+    },
+  );
+
+  return result;
+}
+
+export function describePayloadUpdateResult(
+  result: PayloadUpdateResult,
+): string {
+  return `Updated payload ${result.payloadArtifactIri} by replacing ${result.workingFilePath} and updating ${result.updatedPaths.length} working file.`;
+}
+
+function resolveLoggers(
+  options: ExecutePayloadUpdateOptions,
+): {
+  operationalLogger: StructuredLogger;
+  auditLogger: AuditLogger;
+} {
+  return resolveRuntimeLoggers(options);
+}
+
+async function ensureWorkspaceRootExists(workspaceRoot: string): Promise<void> {
+  let stat: Deno.FileInfo;
+  try {
+    stat = await Deno.stat(workspaceRoot);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new PayloadUpdateRuntimeError(
+        `Workspace root does not exist: ${workspaceRoot}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!stat.isDirectory) {
+    throw new PayloadUpdateRuntimeError(
+      `Workspace root is not a directory: ${workspaceRoot}`,
+    );
+  }
+}
+
+function normalizeLocalDesignatorPath(
+  designatorPath: string,
+  fieldName: string,
+): string {
+  const trimmed = designatorPath.trim();
+  if (trimmed.length === 0) {
+    throw new PayloadUpdateRuntimeError(`${fieldName} is required`);
+  }
+  if (trimmed.startsWith("/") || trimmed.endsWith("/")) {
+    throw new PayloadUpdateRuntimeError(
+      `${fieldName} must not start or end with '/'`,
+    );
+  }
+  if (
+    trimmed.includes("\\") || trimmed.includes("?") || trimmed.includes("#")
+  ) {
+    throw new PayloadUpdateRuntimeError(
+      `${fieldName} contains unsupported path characters`,
+    );
+  }
+
+  const segments = trimmed.split("/");
+  if (segments.some((segment) => segment.length === 0)) {
+    throw new PayloadUpdateRuntimeError(
+      `${fieldName} must not contain empty path segments`,
+    );
+  }
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new PayloadUpdateRuntimeError(
+      `${fieldName} must not contain '.' or '..' path segments`,
+    );
+  }
+  if (segments.some((segment) => reservedDesignatorSegments.has(segment))) {
+    throw new PayloadUpdateRuntimeError(
+      `${fieldName} must not contain reserved path segments`,
+    );
+  }
+  for (const segment of segments) {
+    if (!safeDesignatorSegmentPattern.test(segment)) {
+      throw new PayloadUpdateRuntimeError(
+        `normalizeDesignatorPath rejected segment "${segment}" in ${fieldName}: toKnopPath only accepts path segments matching [A-Za-z0-9._-]+`,
+      );
+    }
+  }
+
+  return trimmed;
+}
+
+async function resolveReplacementSource(
+  workspaceRoot: string,
+  source: string,
+): Promise<{ absoluteSourcePath: string; replacementPayloadTurtle: string }> {
+  const trimmed = source.trim();
+  if (trimmed.length === 0) {
+    throw new PayloadUpdateRuntimeError(
+      "payload update requires a source path or file URL",
+    );
+  }
+
+  const absoluteSourcePath = resolveSourcePath(workspaceRoot, trimmed);
+  let stat: Deno.FileInfo;
+  try {
+    stat = await Deno.stat(absoluteSourcePath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new PayloadUpdateRuntimeError(
+        `payload update source does not exist: ${trimmed}`,
+      );
+    }
+    throw error;
+  }
+
+  if (!stat.isFile) {
+    throw new PayloadUpdateRuntimeError(
+      `payload update source is not a file: ${trimmed}`,
+    );
+  }
+
+  return {
+    absoluteSourcePath,
+    replacementPayloadTurtle: await Deno.readTextFile(absoluteSourcePath),
+  };
+}
+
+function resolveSourcePath(workspaceRoot: string, source: string): string {
+  const parsedUrl = tryParseUrl(source);
+  if (parsedUrl) {
+    if (parsedUrl.protocol !== "file:") {
+      throw new PayloadUpdateRuntimeError(
+        "The current local payload update slice only supports local filesystem sources.",
+      );
+    }
+    return resolve(fromFileUrl(parsedUrl));
+  }
+
+  return isAbsolute(source) ? resolve(source) : resolve(workspaceRoot, source);
+}
+
+function tryParseUrl(value: string): URL | undefined {
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadCurrentPayloadState(
+  workspaceRoot: string,
+  designatorPath: string,
+): Promise<{
+  meshBase: string;
+  currentKnopInventoryTurtle: string;
+  workingFilePath: string;
+}> {
+  const meshMetadataPath = join(workspaceRoot, "_mesh/_meta/meta.ttl");
+  const knopInventoryPath = join(
+    workspaceRoot,
+    `${designatorPath}/_knop/_inventory/inventory.ttl`,
+  );
+  let meshMetadataTurtle: string;
+  let currentKnopInventoryTurtle: string;
+
+  try {
+    [meshMetadataTurtle, currentKnopInventoryTurtle] = await Promise.all([
+      Deno.readTextFile(meshMetadataPath),
+      Deno.readTextFile(knopInventoryPath),
+    ]);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new PayloadUpdateRuntimeError(
+        `Workspace does not contain an existing woven payload surface for ${designatorPath}`,
+      );
+    }
+    throw error;
+  }
+
+  const meshBaseMatch = meshMetadataTurtle.match(
+    /sflo:meshBase "([^"]+)"\^\^xsd:anyURI/,
+  );
+  if (!meshBaseMatch) {
+    throw new PayloadUpdateRuntimeError(
+      "Could not resolve meshBase from _mesh/_meta/meta.ttl",
+    );
+  }
+
+  const payloadBlock = currentKnopInventoryTurtle
+    .split("\n\n")
+    .find((block) =>
+      block.startsWith(
+        `<${designatorPath}> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;`,
+      )
+    );
+  if (!payloadBlock) {
+    throw new PayloadUpdateRuntimeError(
+      `Could not resolve the payload artifact block for ${designatorPath}.`,
+    );
+  }
+
+  const workingFilePathMatch = payloadBlock.match(
+    /sflo:hasWorkingLocatedFile <([^>]+)>/,
+  );
+  if (!workingFilePathMatch) {
+    throw new PayloadUpdateRuntimeError(
+      `Could not resolve the working payload file for ${designatorPath}.`,
+    );
+  }
+
+  const workingFilePath = workingFilePathMatch[1]!;
+  try {
+    const stat = await Deno.stat(join(workspaceRoot, workingFilePath));
+    if (!stat.isFile) {
+      throw new PayloadUpdateRuntimeError(
+        `Resolved working payload path is not a file for ${designatorPath}: ${workingFilePath}`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new PayloadUpdateRuntimeError(
+        `Workspace is missing the working payload file for ${designatorPath}: ${workingFilePath}`,
+      );
+    }
+    throw error;
+  }
+
+  return {
+    meshBase: meshBaseMatch[1]!,
+    currentKnopInventoryTurtle,
+    workingFilePath,
+  };
+}
+
+function assertUpdatedTargetsExist(
+  workspaceRoot: string,
+  plan: PayloadUpdatePlan,
+): void {
+  for (const file of plan.updatedFiles) {
+    const absolutePath = join(workspaceRoot, file.path);
+    try {
+      Deno.statSync(absolutePath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        throw new PayloadUpdateRuntimeError(
+          `payload update target does not exist: ${file.path}`,
+        );
+      }
+      throw error;
+    }
+  }
+}
+
+function validateRdfPlan(plan: PayloadUpdatePlan): void {
+  const parser = new Parser();
+
+  for (const file of plan.updatedFiles) {
+    if (!file.path.endsWith(".ttl")) {
+      continue;
+    }
+    try {
+      parser.parse(file.contents);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new PayloadUpdateRuntimeError(
+        `Generated RDF did not parse for ${file.path}: ${message}`,
+      );
+    }
+  }
+}
+
+async function applyPayloadUpdateAtomically(
+  workspaceRoot: string,
+  plan: PayloadUpdatePlan,
+): Promise<void> {
+  const file = plan.updatedFiles[0]!;
+  const absolutePath = join(workspaceRoot, file.path);
+  const directoryPath = dirname(absolutePath);
+  const stagedPayloadUpdate: StagedPayloadUpdate = {
+    absolutePath,
+    tempPath: join(
+      directoryPath,
+      `.weave-staged-${crypto.randomUUID()}.tmp`,
+    ),
+    backupPath: join(
+      directoryPath,
+      `.weave-backup-${crypto.randomUUID()}.ttl`,
+    ),
+  };
+
+  await Deno.writeTextFile(stagedPayloadUpdate.tempPath, file.contents, {
+    createNew: true,
+  });
+
+  try {
+    await Deno.copyFile(absolutePath, stagedPayloadUpdate.backupPath);
+    await Deno.rename(stagedPayloadUpdate.tempPath, absolutePath);
+  } catch (error) {
+    try {
+      await removePathIfExists(stagedPayloadUpdate.tempPath);
+      if (await pathExists(stagedPayloadUpdate.backupPath)) {
+        await removePathIfExists(absolutePath);
+        await Deno.rename(stagedPayloadUpdate.backupPath, absolutePath);
+      }
+    } catch (rollbackError) {
+      const message = error instanceof Error ? error.message : String(error);
+      const rollbackMessage = rollbackError instanceof Error
+        ? rollbackError.message
+        : String(rollbackError);
+      throw new PayloadUpdateRuntimeError(
+        `Atomic payload update failed: ${message}; rollback also failed: ${rollbackMessage}`,
+      );
+    }
+
+    throw error;
+  }
+
+  await removePathIfExists(stagedPayloadUpdate.backupPath);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function removePathIfExists(path: string): Promise<void> {
+  try {
+    await Deno.remove(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/runtime/payload/update_test.ts
+++ b/src/runtime/payload/update_test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "@std/assert";
+import { describePayloadUpdateResult } from "./update.ts";
+
+Deno.test("describePayloadUpdateResult uses singular file grammar", () => {
+  assertEquals(
+    describePayloadUpdateResult({
+      meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+      designatorPath: "alice/bio",
+      payloadArtifactIri:
+        "https://semantic-flow.github.io/mesh-alice-bio/alice/bio",
+      workingFilePath: "alice-bio.ttl",
+      updatedPaths: ["alice-bio.ttl"],
+    }),
+    "Updated payload https://semantic-flow.github.io/mesh-alice-bio/alice/bio by replacing working file alice-bio.ttl (updated 1 file).",
+  );
+});
+
+Deno.test("describePayloadUpdateResult uses plural file grammar", () => {
+  assertEquals(
+    describePayloadUpdateResult({
+      meshBase: "https://semantic-flow.github.io/mesh-alice-bio/",
+      designatorPath: "alice/bio",
+      payloadArtifactIri:
+        "https://semantic-flow.github.io/mesh-alice-bio/alice/bio",
+      workingFilePath: "alice-bio.ttl",
+      updatedPaths: ["alice-bio.ttl", "alice-bio-2.ttl"],
+    }),
+    "Updated payload https://semantic-flow.github.io/mesh-alice-bio/alice/bio by replacing working file alice-bio.ttl (updated 2 files).",
+  );
+});

--- a/src/runtime/weave/pages.ts
+++ b/src/runtime/weave/pages.ts
@@ -47,6 +47,34 @@ export function renderResourcePage(
 `;
   }
 
+  if (page.kind === "referenceCatalog") {
+    const currentLinks = page.currentLinks.map((link) =>
+      `        <li id="${link.fragment}"><code>#${link.fragment}</code>: ${link.referenceRoleLabel} reference target <code>${link.referenceTargetPath}</code>.</li>`
+    ).join("\n");
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${meshLabel} ${resourcePath}</title>
+  <link rel="canonical" href="${canonical}">
+</head>
+<body>
+  <main>
+    <h1>${page.catalogPath}</h1>
+    <p>Resource page for the ${page.ownerDesignatorPath} ReferenceCatalog artifact.</p>
+    <section>
+      <h2>Current Links</h2>
+      <ul>
+${currentLinks}
+      </ul>
+    </section>
+  </main>
+</body>
+</html>
+`;
+  }
+
   return `<!doctype html>
 <html lang="en">
 <head>

--- a/src/runtime/weave/pages.ts
+++ b/src/runtime/weave/pages.ts
@@ -19,28 +19,34 @@ export function renderResourcePage(
   const resourcePath = toResourcePath(page.path);
   const canonical = new URL(resourcePath, meshBase).href;
   const meshLabel = deriveMeshLabel(meshBase);
+  const escapedResourcePath = escapeHtml(resourcePath);
+  const escapedCanonical = escapeHtml(canonical);
+  const escapedMeshLabel = escapeHtml(meshLabel);
 
   if (page.kind === "identifier") {
-    const workingFileSentence = page.workingFilePath
+    const workingFileHref = page.workingFilePath
+      ? toRelativeHref(page.path, page.workingFilePath)
+      : undefined;
+    const workingFileSentence = workingFileHref
       ? ` and currently uses the working RDF file <a href="${
-        toRelativeHref(page.path, page.workingFilePath)
-      }">${toRelativeHref(page.path, page.workingFilePath)}</a>`
+        escapeHtml(workingFileHref)
+      }">${escapeHtml(workingFileHref)}</a>`
       : "";
 
     return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>${meshLabel} ${resourcePath}</title>
-  <link rel="canonical" href="${canonical}">
+  <title>${escapedMeshLabel} ${escapedResourcePath}</title>
+  <link rel="canonical" href="${escapedCanonical}">
 </head>
 <body>
   <main>
-    <h1><strong>${page.designatorPath}</strong></h1>
-    <p>Resource page for the Semantic Flow identifier <a href="${canonical}">${canonical}</a>.</p>
+    <h1><strong>${escapeHtml(page.designatorPath)}</strong></h1>
+    <p>Resource page for the Semantic Flow identifier <a href="${escapedCanonical}">${escapedCanonical}</a>.</p>
   </main>
   <footer>
-    <small>The Semantic Flow identifier <a href="${canonical}">${canonical}</a> has an associated Knop at <a href="./_knop">./_knop</a>${workingFileSentence}.</small>
+    <small>The Semantic Flow identifier <a href="${escapedCanonical}">${escapedCanonical}</a> has an associated Knop at <a href="./_knop">./_knop</a>${workingFileSentence}.</small>
   </footer>
 </body>
 </html>
@@ -49,20 +55,26 @@ export function renderResourcePage(
 
   if (page.kind === "referenceCatalog") {
     const currentLinks = page.currentLinks.map((link) =>
-      `        <li id="${link.fragment}"><code>#${link.fragment}</code>: ${link.referenceRoleLabel} reference target <code>${link.referenceTargetPath}</code>.</li>`
+      `        <li id="${escapeHtml(link.fragment)}"><code>#${
+        escapeHtml(link.fragment)
+      }</code>: ${escapeHtml(link.referenceRoleLabel)} reference target <code>${
+        escapeHtml(link.referenceTargetPath)
+      }</code>.</li>`
     ).join("\n");
 
     return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>${meshLabel} ${resourcePath}</title>
-  <link rel="canonical" href="${canonical}">
+  <title>${escapedMeshLabel} ${escapedResourcePath}</title>
+  <link rel="canonical" href="${escapedCanonical}">
 </head>
 <body>
   <main>
-    <h1>${page.catalogPath}</h1>
-    <p>Resource page for the ${page.ownerDesignatorPath} ReferenceCatalog artifact.</p>
+    <h1>${escapeHtml(page.catalogPath)}</h1>
+    <p>Resource page for the ${
+      escapeHtml(page.ownerDesignatorPath)
+    } ReferenceCatalog artifact.</p>
     <section>
       <h2>Current Links</h2>
       <ul>
@@ -79,13 +91,13 @@ ${currentLinks}
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>${meshLabel} ${resourcePath}</title>
-  <link rel="canonical" href="${canonical}">
+  <title>${escapedMeshLabel} ${escapedResourcePath}</title>
+  <link rel="canonical" href="${escapedCanonical}">
 </head>
 <body>
   <main>
-    <h1>${resourcePath}</h1>
-    <p>${page.description}</p>
+    <h1>${escapedResourcePath}</h1>
+    <p>${escapeHtml(page.description)}</p>
   </main>
 </body>
 </html>
@@ -110,4 +122,13 @@ function deriveMeshLabel(meshBase: string): string {
     segment.length > 0
   );
   return segments[segments.length - 1] ?? "_mesh";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }

--- a/src/runtime/weave/pages_test.ts
+++ b/src/runtime/weave/pages_test.ts
@@ -32,3 +32,43 @@ Deno.test("renderResourcePage renders identifier pages with working file links",
 `,
   );
 });
+
+Deno.test("renderResourcePage renders current ReferenceCatalog pages with fragment anchors", () => {
+  assertEquals(
+    renderResourcePage(
+      "https://semantic-flow.github.io/mesh-alice-bio/",
+      {
+        kind: "referenceCatalog",
+        path: "alice/_knop/_references/index.html",
+        catalogPath: "alice/_knop/_references",
+        ownerDesignatorPath: "alice",
+        currentLinks: [{
+          fragment: "reference001",
+          referenceRoleLabel: "canonical",
+          referenceTargetPath: "alice/bio",
+        }],
+      },
+    ),
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>mesh-alice-bio alice/_knop/_references</title>
+  <link rel="canonical" href="https://semantic-flow.github.io/mesh-alice-bio/alice/_knop/_references">
+</head>
+<body>
+  <main>
+    <h1>alice/_knop/_references</h1>
+    <p>Resource page for the alice ReferenceCatalog artifact.</p>
+    <section>
+      <h2>Current Links</h2>
+      <ul>
+        <li id="reference001"><code>#reference001</code>: canonical reference target <code>alice/bio</code>.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>
+`,
+  );
+});

--- a/src/runtime/weave/pages_test.ts
+++ b/src/runtime/weave/pages_test.ts
@@ -72,3 +72,43 @@ Deno.test("renderResourcePage renders current ReferenceCatalog pages with fragme
 `,
   );
 });
+
+Deno.test("renderResourcePage escapes dynamic ReferenceCatalog HTML fragments", () => {
+  assertEquals(
+    renderResourcePage(
+      "https://semantic-flow.github.io/mesh-alice-bio/",
+      {
+        kind: "referenceCatalog",
+        path: "alice/_knop/_references/index.html",
+        catalogPath: 'alice/_knop/_references<&">',
+        ownerDesignatorPath: 'alice & "bob"',
+        currentLinks: [{
+          fragment: "reference&<>\"'001",
+          referenceRoleLabel: 'canonical & <primary> "role"',
+          referenceTargetPath: 'alice/bio?x=<y>&z="1"',
+        }],
+      },
+    ),
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>mesh-alice-bio alice/_knop/_references</title>
+  <link rel="canonical" href="https://semantic-flow.github.io/mesh-alice-bio/alice/_knop/_references">
+</head>
+<body>
+  <main>
+    <h1>alice/_knop/_references&lt;&amp;&quot;&gt;</h1>
+    <p>Resource page for the alice &amp; &quot;bob&quot; ReferenceCatalog artifact.</p>
+    <section>
+      <h2>Current Links</h2>
+      <ul>
+        <li id="reference&amp;&lt;&gt;&quot;&#39;001"><code>#reference&amp;&lt;&gt;&quot;&#39;001</code>: canonical &amp; &lt;primary&gt; &quot;role&quot; reference target <code>alice/bio?x=&lt;y&gt;&amp;z=&quot;1&quot;</code>.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>
+`,
+  );
+});

--- a/src/runtime/weave/weave.ts
+++ b/src/runtime/weave/weave.ts
@@ -4,6 +4,7 @@ import type { PlannedFile } from "../../core/planned_file.ts";
 import {
   type PayloadWorkingArtifact,
   planWeave,
+  type ReferenceCatalogWorkingArtifact,
   type WeaveableKnopCandidate,
   WeaveInputError,
   type WeavePlan,
@@ -226,11 +227,7 @@ async function loadWeaveableKnopCandidates(
       throw error;
     }
 
-    if (currentKnopInventoryTurtle.includes("sflo:hasArtifactHistory")) {
-      continue;
-    }
-
-    candidates.push({
+    const candidate: WeaveableKnopCandidate = {
       designatorPath,
       currentKnopMetadataTurtle,
       currentKnopInventoryTurtle,
@@ -239,7 +236,18 @@ async function loadWeaveableKnopCandidates(
         designatorPath,
         currentKnopInventoryTurtle,
       ),
-    });
+      referenceCatalogArtifact: await loadReferenceCatalogWorkingArtifact(
+        workspaceRoot,
+        designatorPath,
+        currentKnopInventoryTurtle,
+      ),
+    };
+
+    if (!isWeaveableKnopCandidate(candidate)) {
+      continue;
+    }
+
+    candidates.push(candidate);
   }
 
   return candidates.sort((left, right) =>
@@ -299,6 +307,97 @@ async function loadPayloadWorkingArtifact(
     }
     throw error;
   }
+}
+
+async function loadReferenceCatalogWorkingArtifact(
+  workspaceRoot: string,
+  designatorPath: string,
+  currentKnopInventoryTurtle: string,
+): Promise<ReferenceCatalogWorkingArtifact | undefined> {
+  const knopPath = `${designatorPath}/_knop`;
+  const referenceCatalogPath = `${knopPath}/_references`;
+  if (
+    !currentKnopInventoryTurtle.includes(
+      `sflo:hasReferenceCatalog <${referenceCatalogPath}>`,
+    )
+  ) {
+    return undefined;
+  }
+
+  const referenceCatalogBlock = currentKnopInventoryTurtle
+    .split("\n\n")
+    .find((block) =>
+      block.startsWith(
+        `<${referenceCatalogPath}> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;`,
+      )
+    );
+
+  if (!referenceCatalogBlock) {
+    throw new WeaveRuntimeError(
+      `Could not resolve the ReferenceCatalog block for ${designatorPath}.`,
+    );
+  }
+
+  const workingFilePathMatch = referenceCatalogBlock.match(
+    /sflo:hasWorkingLocatedFile <([^>]+)>/,
+  );
+  if (!workingFilePathMatch) {
+    throw new WeaveRuntimeError(
+      `Could not resolve the working ReferenceCatalog file for ${designatorPath}.`,
+    );
+  }
+
+  const workingFilePath = workingFilePathMatch[1]!;
+  try {
+    return {
+      workingFilePath,
+      currentReferenceCatalogTurtle: await Deno.readTextFile(
+        join(workspaceRoot, workingFilePath),
+      ),
+    };
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new WeaveRuntimeError(
+        `Workspace is missing the working ReferenceCatalog file for ${designatorPath}: ${workingFilePath}`,
+      );
+    }
+    throw error;
+  }
+}
+
+function isWeaveableKnopCandidate(candidate: WeaveableKnopCandidate): boolean {
+  const designatorPath = candidate.designatorPath;
+  const knopPath = `${designatorPath}/_knop`;
+  const payloadRelationship = `sflo:hasPayloadArtifact <${designatorPath}>`;
+  const payloadHasHistory = candidate.currentKnopInventoryTurtle.includes(
+    `sflo:hasArtifactHistory <${designatorPath}/_history001>`,
+  );
+  const referenceCatalogPath = `${knopPath}/_references`;
+  const referenceCatalogRelationship =
+    `sflo:hasReferenceCatalog <${referenceCatalogPath}>`;
+  const referenceCatalogHasHistory = candidate.currentKnopInventoryTurtle
+    .includes(`sflo:hasArtifactHistory <${referenceCatalogPath}/_history001>`);
+  const knopInventoryHasHistory = candidate.currentKnopInventoryTurtle.includes(
+    `sflo:hasArtifactHistory <${knopPath}/_inventory/_history001>`,
+  );
+
+  if (
+    candidate.currentKnopInventoryTurtle.includes(
+      referenceCatalogRelationship,
+    ) &&
+    !referenceCatalogHasHistory
+  ) {
+    return candidate.referenceCatalogArtifact !== undefined;
+  }
+
+  if (
+    candidate.currentKnopInventoryTurtle.includes(payloadRelationship) &&
+    !payloadHasHistory
+  ) {
+    return candidate.payloadArtifact !== undefined;
+  }
+
+  return !knopInventoryHasHistory;
 }
 
 function assertUpdatedTargetsExist(

--- a/src/runtime/weave/weave.ts
+++ b/src/runtime/weave/weave.ts
@@ -10,6 +10,7 @@ import {
   WeaveInputError,
   type WeavePlan,
   type WeaveRequest,
+  type WeaveSlice,
 } from "../../core/weave/weave.ts";
 import { resolveRuntimeLoggers } from "../logging/factory.ts";
 import type { AuditLogger } from "../logging/audit_logger.ts";
@@ -266,7 +267,7 @@ async function loadWeaveableKnopCandidates(
         );
     }
 
-    if (!isWeaveableKnopCandidate(candidate)) {
+    if (!isWeaveableKnopCandidate(candidate, slice)) {
       continue;
     }
 
@@ -388,12 +389,10 @@ async function loadReferenceCatalogWorkingArtifact(
   }
 }
 
-function isWeaveableKnopCandidate(candidate: WeaveableKnopCandidate): boolean {
-  const slice = detectPendingWeaveSlice(
-    candidate.designatorPath,
-    candidate.currentKnopInventoryTurtle,
-  );
-
+function isWeaveableKnopCandidate(
+  candidate: WeaveableKnopCandidate,
+  slice: WeaveSlice,
+): boolean {
   if (slice === "firstReferenceCatalogWeave") {
     return candidate.referenceCatalogArtifact !== undefined;
   }

--- a/src/runtime/weave/weave.ts
+++ b/src/runtime/weave/weave.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "@std/path";
 import { Parser } from "n3";
 import type { PlannedFile } from "../../core/planned_file.ts";
 import {
+  detectPendingWeaveSlice,
   type PayloadWorkingArtifact,
   planWeave,
   type ReferenceCatalogWorkingArtifact,
@@ -59,6 +60,7 @@ export async function executeWeave(
     const weaveableKnops = await loadWeaveableKnopCandidates(
       workspaceRoot,
       meshState.currentMeshInventoryTurtle,
+      options.request?.designatorPaths ?? [],
     );
     plan = planWeave({
       request: options.request ?? {},
@@ -195,6 +197,7 @@ async function loadMeshState(
 async function loadWeaveableKnopCandidates(
   workspaceRoot: string,
   currentMeshInventoryTurtle: string,
+  requestedDesignatorPaths: readonly string[],
 ): Promise<readonly WeaveableKnopCandidate[]> {
   const knopMatches = [
     ...currentMeshInventoryTurtle.matchAll(/<([^>]+\/_knop)> a sflo:Knop ;/g),
@@ -202,9 +205,14 @@ async function loadWeaveableKnopCandidates(
   const designatorPaths = knopMatches.map((match) =>
     match[1]!.slice(0, -"/_knop".length)
   );
+  const requested = normalizeRequestedDesignatorPaths(requestedDesignatorPaths);
 
   const candidates: WeaveableKnopCandidate[] = [];
   for (const designatorPath of designatorPaths) {
+    if (requested && !requested.has(designatorPath)) {
+      continue;
+    }
+
     const knopPath = `${designatorPath}/_knop`;
     const metadataPath = join(workspaceRoot, `${knopPath}/_meta/meta.ttl`);
     const inventoryPath = join(
@@ -231,17 +239,32 @@ async function loadWeaveableKnopCandidates(
       designatorPath,
       currentKnopMetadataTurtle,
       currentKnopInventoryTurtle,
-      payloadArtifact: await loadPayloadWorkingArtifact(
-        workspaceRoot,
-        designatorPath,
-        currentKnopInventoryTurtle,
-      ),
-      referenceCatalogArtifact: await loadReferenceCatalogWorkingArtifact(
-        workspaceRoot,
-        designatorPath,
-        currentKnopInventoryTurtle,
-      ),
     };
+    const slice = detectPendingWeaveSlice(
+      designatorPath,
+      currentKnopInventoryTurtle,
+    );
+
+    if (!slice) {
+      continue;
+    }
+
+    if (slice === "firstPayloadWeave") {
+      candidate.payloadArtifact = await loadPayloadWorkingArtifact(
+        workspaceRoot,
+        designatorPath,
+        currentKnopInventoryTurtle,
+      );
+    }
+
+    if (slice === "firstReferenceCatalogWeave") {
+      candidate.referenceCatalogArtifact =
+        await loadReferenceCatalogWorkingArtifact(
+          workspaceRoot,
+          designatorPath,
+          currentKnopInventoryTurtle,
+        );
+    }
 
     if (!isWeaveableKnopCandidate(candidate)) {
       continue;
@@ -366,38 +389,30 @@ async function loadReferenceCatalogWorkingArtifact(
 }
 
 function isWeaveableKnopCandidate(candidate: WeaveableKnopCandidate): boolean {
-  const designatorPath = candidate.designatorPath;
-  const knopPath = `${designatorPath}/_knop`;
-  const payloadRelationship = `sflo:hasPayloadArtifact <${designatorPath}>`;
-  const payloadHasHistory = candidate.currentKnopInventoryTurtle.includes(
-    `sflo:hasArtifactHistory <${designatorPath}/_history001>`,
-  );
-  const referenceCatalogPath = `${knopPath}/_references`;
-  const referenceCatalogRelationship =
-    `sflo:hasReferenceCatalog <${referenceCatalogPath}>`;
-  const referenceCatalogHasHistory = candidate.currentKnopInventoryTurtle
-    .includes(`sflo:hasArtifactHistory <${referenceCatalogPath}/_history001>`);
-  const knopInventoryHasHistory = candidate.currentKnopInventoryTurtle.includes(
-    `sflo:hasArtifactHistory <${knopPath}/_inventory/_history001>`,
+  const slice = detectPendingWeaveSlice(
+    candidate.designatorPath,
+    candidate.currentKnopInventoryTurtle,
   );
 
-  if (
-    candidate.currentKnopInventoryTurtle.includes(
-      referenceCatalogRelationship,
-    ) &&
-    !referenceCatalogHasHistory
-  ) {
+  if (slice === "firstReferenceCatalogWeave") {
     return candidate.referenceCatalogArtifact !== undefined;
   }
 
-  if (
-    candidate.currentKnopInventoryTurtle.includes(payloadRelationship) &&
-    !payloadHasHistory
-  ) {
+  if (slice === "firstPayloadWeave") {
     return candidate.payloadArtifact !== undefined;
   }
 
-  return !knopInventoryHasHistory;
+  return slice === "firstKnopWeave";
+}
+
+function normalizeRequestedDesignatorPaths(
+  requestedDesignatorPaths: readonly string[],
+): ReadonlySet<string> | undefined {
+  const normalized = requestedDesignatorPaths
+    .map((path) => path.trim())
+    .filter((path) => path.length > 0);
+
+  return normalized.length === 0 ? undefined : new Set(normalized);
 }
 
 function assertUpdatedTargetsExist(

--- a/tests/e2e/integrate_cli_test.ts
+++ b/tests/e2e/integrate_cli_test.ts
@@ -102,6 +102,93 @@ Deno.test("weave integrate matches the manifest-scoped alice-bio integrated fixt
   await Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl"));
 });
 
+Deno.test("weave integrate rejects conflicting designator paths before logging or execution", async () => {
+  const workspaceRoot = await createTestTmpDir("weave-e2e-integrate-conflict-");
+  await materializeMeshAliceBioBranch(
+    "05-alice-knop-created-woven",
+    workspaceRoot,
+  );
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "src/main.ts",
+      "integrate",
+      "alice-bio.ttl",
+      "alice/bio",
+      "--designator-path",
+      "bob/bio",
+      "--workspace",
+      workspaceRoot,
+    ],
+    cwd: new URL(".", repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  assertEquals(output.success, false);
+  assert(
+    stderr.includes("integrate received conflicting designator paths"),
+    stderr,
+  );
+  await assertRejects(
+    () => Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl")),
+    Deno.errors.NotFound,
+  );
+  await assertPathAbsent(
+    join(workspaceRoot, "alice/bio/_knop/_inventory/inventory.ttl"),
+  );
+});
+
+Deno.test("weave integrate requires a designator path before logging or execution", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-e2e-integrate-missing-designator-",
+  );
+  await materializeMeshAliceBioBranch(
+    "05-alice-knop-created-woven",
+    workspaceRoot,
+  );
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "src/main.ts",
+      "integrate",
+      "alice-bio.ttl",
+      "--workspace",
+      workspaceRoot,
+    ],
+    cwd: new URL(".", repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  assertEquals(output.success, false);
+  assert(
+    stderr.includes(
+      "integrate requires a designator path as [designatorPath] or --designator-path",
+    ),
+    stderr,
+  );
+  await assertRejects(
+    () => Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl")),
+    Deno.errors.NotFound,
+  );
+  await assertPathAbsent(
+    join(workspaceRoot, "alice/bio/_knop/_inventory/inventory.ttl"),
+  );
+});
+
 async function listRelativeFiles(
   root: string,
   excludedPrefix: string,

--- a/tests/e2e/payload_update_cli_test.ts
+++ b/tests/e2e/payload_update_cli_test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { join, relative } from "@std/path";
 import { compareRdfContent } from "../../dependencies/github.com/spectacular-voyage/accord/src/checker/compare_rdf.ts";
 import {
@@ -103,6 +103,116 @@ Deno.test("weave payload update matches the manifest-scoped alice-bio updated fi
 
   await Deno.stat(join(workspaceRoot, ".weave/logs/operational.jsonl"));
   await Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl"));
+});
+
+Deno.test("weave payload update rejects conflicting designator paths before logging or execution", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-e2e-payload-update-conflict-",
+  );
+  await materializeMeshAliceBioBranch(
+    "09-alice-bio-referenced-woven",
+    workspaceRoot,
+  );
+
+  const sourceRoot = await createTestTmpDir(
+    "weave-e2e-payload-update-conflict-source-",
+  );
+  const sourcePath = join(sourceRoot, "alice-bio-v2.ttl");
+  await Deno.writeTextFile(
+    sourcePath,
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "src/main.ts",
+      "payload",
+      "update",
+      sourcePath,
+      "alice/bio",
+      "--designator-path",
+      "bob/bio",
+      "--workspace",
+      workspaceRoot,
+    ],
+    cwd: new URL(".", repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  assertEquals(output.success, false);
+  assert(
+    stderr.includes("payload update received conflicting designator paths"),
+    stderr,
+  );
+  await assertRejects(
+    () => Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl")),
+    Deno.errors.NotFound,
+  );
+  assertEquals(
+    await Deno.readTextFile(join(workspaceRoot, "alice-bio.ttl")),
+    await readMeshAliceBioBranchFile(
+      "09-alice-bio-referenced-woven",
+      "alice-bio.ttl",
+    ),
+  );
+});
+
+Deno.test("weave payload update requires a designator path before logging or execution", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-e2e-payload-update-missing-designator-",
+  );
+  await materializeMeshAliceBioBranch(
+    "09-alice-bio-referenced-woven",
+    workspaceRoot,
+  );
+
+  const sourceRoot = await createTestTmpDir(
+    "weave-e2e-payload-update-missing-designator-source-",
+  );
+  const sourcePath = join(sourceRoot, "alice-bio-v2.ttl");
+  await Deno.writeTextFile(
+    sourcePath,
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "src/main.ts",
+      "payload",
+      "update",
+      sourcePath,
+      "--workspace",
+      workspaceRoot,
+    ],
+    cwd: new URL(".", repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  assertEquals(output.success, false);
+  assert(
+    stderr.includes(
+      "payload update requires a designator path as [designatorPath] or --designator-path",
+    ),
+    stderr,
+  );
+  await assertRejects(
+    () => Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl")),
+    Deno.errors.NotFound,
+  );
 });
 
 async function listRelativeFiles(

--- a/tests/e2e/payload_update_cli_test.ts
+++ b/tests/e2e/payload_update_cli_test.ts
@@ -1,0 +1,136 @@
+import { assert, assertEquals } from "@std/assert";
+import { join, relative } from "@std/path";
+import { compareRdfContent } from "../../dependencies/github.com/spectacular-voyage/accord/src/checker/compare_rdf.ts";
+import {
+  getManifestFileExpectations,
+  readSingleTransitionCase,
+} from "../support/accord_manifest.ts";
+import {
+  listMeshAliceBioBranchFiles,
+  materializeMeshAliceBioBranch,
+  readMeshAliceBioBranchFile,
+  resolveMeshAliceBioConformanceManifestPath,
+} from "../support/mesh_alice_bio_fixture.ts";
+import { createTestTmpDir } from "../support/test_tmp.ts";
+
+const repoRoot = new URL("../../", import.meta.url);
+
+Deno.test("weave payload update matches the manifest-scoped alice-bio updated fixture as a black-box CLI run", async () => {
+  const manifestPath = resolveMeshAliceBioConformanceManifestPath(
+    "10-alice-bio-updated.jsonld",
+  );
+  const transitionCase = await readSingleTransitionCase(manifestPath);
+  assertEquals(transitionCase.operationId, "payload.update");
+
+  const workspaceRoot = await createTestTmpDir("weave-e2e-payload-update-");
+  await materializeMeshAliceBioBranch(transitionCase.fromRef!, workspaceRoot);
+
+  const sourceRoot = await createTestTmpDir(
+    "weave-e2e-payload-update-source-",
+  );
+  const sourcePath = join(sourceRoot, "alice-bio-v2.ttl");
+  await Deno.writeTextFile(
+    sourcePath,
+    await readMeshAliceBioBranchFile(transitionCase.toRef!, "alice-bio.ttl"),
+  );
+
+  const command = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "src/main.ts",
+      "payload",
+      "update",
+      sourcePath,
+      "--designator-path",
+      "alice/bio",
+      "--workspace",
+      workspaceRoot,
+    ],
+    cwd: new URL(".", repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  const stdout = new TextDecoder().decode(output.stdout);
+  const stderr = new TextDecoder().decode(output.stderr);
+
+  assert(output.success, stderr);
+  assert(stdout.includes("Updated payload"), stdout);
+
+  assertEquals(
+    await listRelativeFiles(workspaceRoot, ".weave/"),
+    await listMeshAliceBioBranchFiles(transitionCase.toRef!),
+  );
+
+  const fileExpectations = getManifestFileExpectations(transitionCase);
+  for (const fileExpectation of fileExpectations) {
+    const path = fileExpectation.path;
+    if (!path) {
+      continue;
+    }
+
+    const actualBytes = await Deno.readFile(join(workspaceRoot, path));
+    const expectedBytes = new TextEncoder().encode(
+      await readMeshAliceBioBranchFile(transitionCase.toRef!, path),
+    );
+    const compareMode = fileExpectation.compareMode ?? "bytes";
+
+    if (compareMode === "rdfCanonical") {
+      assertEquals(
+        await compareRdfContent({
+          left: actualBytes,
+          right: expectedBytes,
+          path,
+        }),
+        true,
+      );
+      continue;
+    }
+
+    if (compareMode === "text") {
+      assertEquals(
+        new TextDecoder().decode(actualBytes),
+        new TextDecoder().decode(expectedBytes),
+      );
+      continue;
+    }
+
+    assertEquals(actualBytes, expectedBytes);
+  }
+
+  await Deno.stat(join(workspaceRoot, ".weave/logs/operational.jsonl"));
+  await Deno.stat(join(workspaceRoot, ".weave/logs/security-audit.jsonl"));
+});
+
+async function listRelativeFiles(
+  root: string,
+  excludedPrefix: string,
+): Promise<string[]> {
+  const paths: string[] = [];
+
+  for await (const entry of walkFiles(root)) {
+    const rel = relative(root, entry).replaceAll("\\", "/");
+    if (rel.startsWith(excludedPrefix)) {
+      continue;
+    }
+    paths.push(rel);
+  }
+
+  return paths.sort();
+}
+
+async function* walkFiles(root: string): AsyncGenerator<string> {
+  for await (const entry of Deno.readDir(root)) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory) {
+      yield* walkFiles(path);
+      continue;
+    }
+    if (entry.isFile) {
+      yield path;
+    }
+  }
+}

--- a/tests/e2e/weave_cli_test.ts
+++ b/tests/e2e/weave_cli_test.ts
@@ -29,6 +29,13 @@ Deno.test("weave matches the manifest-scoped alice bio integrated-woven fixture 
   });
 });
 
+Deno.test("weave matches the manifest-scoped alice bio referenced-woven fixture as a black-box CLI run", async () => {
+  await assertWeaveTransitionMatchesManifest({
+    manifestName: "09-alice-bio-referenced-woven.jsonld",
+    expectedStdoutFragment: "Wove 1 designator path",
+  });
+});
+
 async function assertWeaveTransitionMatchesManifest(
   options: {
     manifestName: string;

--- a/tests/integration/payload_update_test.ts
+++ b/tests/integration/payload_update_test.ts
@@ -102,6 +102,71 @@ Deno.test("executePayloadUpdate accepts a file URL source", async () => {
   );
 });
 
+Deno.test("executePayloadUpdate treats colon-containing source filenames as filesystem paths", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-payload-update-colon-path-",
+  );
+  await materializeMeshAliceBioBranch(
+    "09-alice-bio-referenced-woven",
+    workspaceRoot,
+  );
+
+  const sourceRoot = await createTestTmpDir(
+    "weave-payload-update-colon-path-source-",
+  );
+  const sourcePath = join(sourceRoot, "alice:bio-v2.ttl");
+  await Deno.writeTextFile(
+    sourcePath,
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+
+  const result = await executePayloadUpdate({
+    workspaceRoot,
+    request: {
+      designatorPath: "alice/bio",
+      source: sourcePath,
+    },
+  });
+
+  assertEquals(result.updatedPaths, ["alice-bio.ttl"]);
+  assertEquals(
+    await Deno.readTextFile(join(workspaceRoot, "alice-bio.ttl")),
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+});
+
+Deno.test("executePayloadUpdate rejects remote source URLs before touching the workspace", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-payload-update-remote-url-",
+  );
+  await materializeMeshAliceBioBranch(
+    "09-alice-bio-referenced-woven",
+    workspaceRoot,
+  );
+
+  const originalPayload = await Deno.readTextFile(
+    join(workspaceRoot, "alice-bio.ttl"),
+  );
+
+  await assertRejects(
+    () =>
+      executePayloadUpdate({
+        workspaceRoot,
+        request: {
+          designatorPath: "alice/bio",
+          source: "https://example.com/alice-bio.ttl",
+        },
+      }),
+    PayloadUpdateRuntimeError,
+    "only supports local filesystem sources",
+  );
+
+  assertEquals(
+    await Deno.readTextFile(join(workspaceRoot, "alice-bio.ttl")),
+    originalPayload,
+  );
+});
+
 Deno.test("executePayloadUpdate rejects invalid Turtle and preserves the working payload file", async () => {
   const workspaceRoot = await createTestTmpDir(
     "weave-payload-update-invalid-rdf-",

--- a/tests/integration/payload_update_test.ts
+++ b/tests/integration/payload_update_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { join } from "@std/path";
 import { executePayloadUpdate } from "../../src/runtime/payload/update.ts";
 import {
@@ -6,6 +6,7 @@ import {
   readMeshAliceBioBranchFile,
 } from "../support/mesh_alice_bio_fixture.ts";
 import { createTestTmpDir } from "../support/test_tmp.ts";
+import { PayloadUpdateRuntimeError } from "../../src/runtime/payload/update.ts";
 
 Deno.test("executePayloadUpdate matches the settled alice-bio updated fixture", async () => {
   const workspaceRoot = await createTestTmpDir("weave-payload-update-");
@@ -65,5 +66,83 @@ Deno.test("executePayloadUpdate matches the settled alice-bio updated fixture", 
       "10-alice-bio-updated",
       "alice/_knop/_references/index.html",
     ),
+  );
+});
+
+Deno.test("executePayloadUpdate accepts a file URL source", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-payload-update-file-url-",
+  );
+  await materializeMeshAliceBioBranch(
+    "09-alice-bio-referenced-woven",
+    workspaceRoot,
+  );
+
+  const sourceRoot = await createTestTmpDir(
+    "weave-payload-update-file-url-source-",
+  );
+  const sourcePath = join(sourceRoot, "alice-bio-v2.ttl");
+  await Deno.writeTextFile(
+    sourcePath,
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+
+  const result = await executePayloadUpdate({
+    workspaceRoot,
+    request: {
+      designatorPath: "alice/bio",
+      source: new URL(`file://${sourcePath}`).href,
+    },
+  });
+
+  assertEquals(result.updatedPaths, ["alice-bio.ttl"]);
+  assertEquals(
+    await Deno.readTextFile(join(workspaceRoot, "alice-bio.ttl")),
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+});
+
+Deno.test("executePayloadUpdate rejects invalid Turtle and preserves the working payload file", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-payload-update-invalid-rdf-",
+  );
+  await materializeMeshAliceBioBranch(
+    "09-alice-bio-referenced-woven",
+    workspaceRoot,
+  );
+
+  const sourceRoot = await createTestTmpDir(
+    "weave-payload-update-invalid-rdf-source-",
+  );
+  const sourcePath = join(sourceRoot, "alice-bio-invalid.ttl");
+  await Deno.writeTextFile(
+    sourcePath,
+    `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix schema: <https://schema.org/> .
+
+<alice> a schema:Person
+`,
+  );
+
+  const originalPayload = await Deno.readTextFile(
+    join(workspaceRoot, "alice-bio.ttl"),
+  );
+
+  await assertRejects(
+    () =>
+      executePayloadUpdate({
+        workspaceRoot,
+        request: {
+          designatorPath: "alice/bio",
+          source: sourcePath,
+        },
+      }),
+    PayloadUpdateRuntimeError,
+    "Generated RDF did not parse",
+  );
+
+  assertEquals(
+    await Deno.readTextFile(join(workspaceRoot, "alice-bio.ttl")),
+    originalPayload,
   );
 });

--- a/tests/integration/payload_update_test.ts
+++ b/tests/integration/payload_update_test.ts
@@ -1,0 +1,69 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { executePayloadUpdate } from "../../src/runtime/payload/update.ts";
+import {
+  materializeMeshAliceBioBranch,
+  readMeshAliceBioBranchFile,
+} from "../support/mesh_alice_bio_fixture.ts";
+import { createTestTmpDir } from "../support/test_tmp.ts";
+
+Deno.test("executePayloadUpdate matches the settled alice-bio updated fixture", async () => {
+  const workspaceRoot = await createTestTmpDir("weave-payload-update-");
+  await materializeMeshAliceBioBranch(
+    "09-alice-bio-referenced-woven",
+    workspaceRoot,
+  );
+
+  const sourceRoot = await createTestTmpDir("weave-payload-update-source-");
+  const sourcePath = join(sourceRoot, "alice-bio-v2.ttl");
+  await Deno.writeTextFile(
+    sourcePath,
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+
+  const result = await executePayloadUpdate({
+    workspaceRoot,
+    request: {
+      designatorPath: "alice/bio",
+      source: sourcePath,
+    },
+  });
+
+  assertEquals(result.designatorPath, "alice/bio");
+  assertEquals(result.workingFilePath, "alice-bio.ttl");
+  assertEquals(result.updatedPaths, ["alice-bio.ttl"]);
+  assertEquals(
+    await Deno.readTextFile(join(workspaceRoot, "alice-bio.ttl")),
+    await readMeshAliceBioBranchFile("10-alice-bio-updated", "alice-bio.ttl"),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(
+        workspaceRoot,
+        "alice/bio/_history001/_s0001/alice-bio-ttl/alice-bio.ttl",
+      ),
+    ),
+    await readMeshAliceBioBranchFile(
+      "10-alice-bio-updated",
+      "alice/bio/_history001/_s0001/alice-bio-ttl/alice-bio.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "_mesh/_inventory/inventory.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "10-alice-bio-updated",
+      "_mesh/_inventory/inventory.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_references/index.html"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "10-alice-bio-updated",
+      "alice/_knop/_references/index.html",
+    ),
+  );
+});

--- a/tests/integration/weave_test.ts
+++ b/tests/integration/weave_test.ts
@@ -206,3 +206,109 @@ Deno.test("executeWeave fails closed when a created weave target already exists"
     "already exists",
   );
 });
+
+Deno.test("executeWeave ignores settled Knops before loading missing working artifacts", async () => {
+  const workspaceRoot = await createTestTmpDir("weave-weave-settled-ignore-");
+  await materializeMeshAliceBioBranch("04-alice-knop-created", workspaceRoot);
+  await addSupplementalKnopToMeshInventory(workspaceRoot, "bob/bio");
+  await writeSupplementalKnopSurface(
+    workspaceRoot,
+    "bob/bio",
+    `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+
+<bob/bio/_knop> a sflo:Knop ;
+  sflo:hasKnopMetadata <bob/bio/_knop/_meta> ;
+  sflo:hasKnopInventory <bob/bio/_knop/_inventory> ;
+  sflo:hasWorkingKnopInventoryFile <bob/bio/_knop/_inventory/inventory.ttl> ;
+  sflo:hasPayloadArtifact <bob/bio> .
+
+<bob/bio> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <bob/bio/_history001> ;
+  sflo:hasWorkingLocatedFile <missing-bob-bio.ttl> .
+
+<bob/bio/_knop/_inventory> a sflo:KnopInventory, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasArtifactHistory <bob/bio/_knop/_inventory/_history001> .
+`,
+  );
+
+  const result = await executeWeave({
+    workspaceRoot,
+  });
+
+  assertEquals(result.wovenDesignatorPaths, ["alice"]);
+});
+
+Deno.test("executeWeave ignores non-requested weave candidates before loading working artifacts", async () => {
+  const workspaceRoot = await createTestTmpDir("weave-weave-requested-ignore-");
+  await materializeMeshAliceBioBranch("04-alice-knop-created", workspaceRoot);
+  await addSupplementalKnopToMeshInventory(workspaceRoot, "bob/bio");
+  await writeSupplementalKnopSurface(
+    workspaceRoot,
+    "bob/bio",
+    `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+
+<bob/bio/_knop> a sflo:Knop ;
+  sflo:hasKnopMetadata <bob/bio/_knop/_meta> ;
+  sflo:hasKnopInventory <bob/bio/_knop/_inventory> ;
+  sflo:hasWorkingKnopInventoryFile <bob/bio/_knop/_inventory/inventory.ttl> ;
+  sflo:hasPayloadArtifact <bob/bio> .
+
+<bob/bio> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <missing-bob-bio.ttl> .
+`,
+  );
+
+  const result = await executeWeave({
+    workspaceRoot,
+    request: {
+      designatorPaths: ["alice"],
+    },
+  });
+
+  assertEquals(result.wovenDesignatorPaths, ["alice"]);
+});
+
+async function addSupplementalKnopToMeshInventory(
+  workspaceRoot: string,
+  designatorPath: string,
+): Promise<void> {
+  const meshInventoryPath = join(
+    workspaceRoot,
+    "_mesh/_inventory/inventory.ttl",
+  );
+  const current = await Deno.readTextFile(meshInventoryPath);
+  await Deno.writeTextFile(
+    meshInventoryPath,
+    `${current.trimEnd()}
+
+<${designatorPath}/_knop> a sflo:Knop ;
+  sflo:hasWorkingKnopInventoryFile <${designatorPath}/_knop/_inventory/inventory.ttl> .
+`,
+  );
+}
+
+async function writeSupplementalKnopSurface(
+  workspaceRoot: string,
+  designatorPath: string,
+  inventoryTurtle: string,
+): Promise<void> {
+  const knopPath = join(workspaceRoot, `${designatorPath}/_knop`);
+  await Deno.mkdir(join(knopPath, "_meta"), { recursive: true });
+  await Deno.mkdir(join(knopPath, "_inventory"), { recursive: true });
+  await Deno.writeTextFile(
+    join(knopPath, "_meta/meta.ttl"),
+    `@base <https://semantic-flow.github.io/mesh-alice-bio/> .
+@prefix sflo: <https://semantic-flow.github.io/semantic-flow-ontology/> .
+
+<${designatorPath}/_knop> a sflo:Knop ;
+  sflo:designatorPath "${designatorPath}" ;
+  sflo:hasWorkingKnopInventoryFile <${designatorPath}/_knop/_inventory/inventory.ttl> .
+`,
+  );
+  await Deno.writeTextFile(
+    join(knopPath, "_inventory/inventory.ttl"),
+    inventoryTurtle,
+  );
+}

--- a/tests/integration/weave_test.ts
+++ b/tests/integration/weave_test.ts
@@ -115,6 +115,79 @@ Deno.test("executeWeave matches the settled alice bio integrated-woven fixture",
   );
 });
 
+Deno.test("executeWeave matches the settled alice bio referenced-woven fixture", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-weave-reference-catalog-",
+  );
+  await materializeMeshAliceBioBranch("08-alice-bio-referenced", workspaceRoot);
+
+  const result = await executeWeave({
+    workspaceRoot,
+  });
+
+  assertEquals(result.wovenDesignatorPaths, ["alice"]);
+  assertEquals(result.updatedPaths, ["alice/_knop/_inventory/inventory.ttl"]);
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_inventory/inventory.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "09-alice-bio-referenced-woven",
+      "alice/_knop/_inventory/inventory.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(
+        workspaceRoot,
+        "alice/_knop/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl",
+      ),
+    ),
+    await readMeshAliceBioBranchFile(
+      "09-alice-bio-referenced-woven",
+      "alice/_knop/_inventory/_history001/_s0002/inventory-ttl/inventory.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_references/references.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "09-alice-bio-referenced-woven",
+      "alice/_knop/_references/references.ttl",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(
+        workspaceRoot,
+        "alice/_knop/_references/_history001/_s0001/references-ttl/references.ttl",
+      ),
+    ),
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_references/references.ttl"),
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "alice/_knop/_references/index.html"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "09-alice-bio-referenced-woven",
+      "alice/_knop/_references/index.html",
+    ),
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(workspaceRoot, "_mesh/_inventory/inventory.ttl"),
+    ),
+    await readMeshAliceBioBranchFile(
+      "09-alice-bio-referenced-woven",
+      "_mesh/_inventory/inventory.ttl",
+    ),
+  );
+});
+
 Deno.test("executeWeave fails closed when a created weave target already exists", async () => {
   const workspaceRoot = await createTestTmpDir("weave-weave-existing-");
   await materializeMeshAliceBioBranch("04-alice-knop-created", workspaceRoot);


### PR DESCRIPTION
- add unit, integration, and black-box CLI coverage for the settled 09-alice-bio-referenced-woven transition
- extend local weave planning and runtime candidate loading to support first ReferenceCatalog weaving on an already-versioned Knop surface
- version alice/_knop/_references into _history001/_s0001 and advance alice/_knop/_inventory to _s0002 while keeping _mesh/_inventory unchanged
- extend the shared page-rendering seam to cover current and historical ReferenceCatalog pages, including the current #reference001 anchor
- update the weave behavior note, codebase overview, decision log, and task note checklist for the carried 08 -> 09 slice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reference-catalog weaving: adds reference-catalog pages and extends weave transitions.
  * New CLI: "weave payload update" to atomically replace a managed payload file with validation, audit/operational logging, and human-readable summaries.
  * Safer HTML rendering: dynamic values in generated pages are HTML-escaped.

* **Documentation**
  * Expanded specs, decision log entries, tasks, and overview documenting weave and payload.update behaviors and acceptance criteria.

* **Tests**
  * Added unit, integration, and end-to-end tests for reference-catalog weaving and payload.update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->