### PR TITLE
fix: accept deno task '--' separator in npm-lib build/smoke scripts

### DIFF
--- a/scripts/build-npm-lib.ts
+++ b/scripts/build-npm-lib.ts
@@ -31,6 +31,9 @@ function parseArgs(args: readonly string[]): BuildNpmLibOptions {
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === "--") {
+      continue;
+    }
     if (arg === "--root") {
       index += 1;
       root = requireArgumentValue(args[index], "--root");

--- a/scripts/smoke-npm-lib.ts
+++ b/scripts/smoke-npm-lib.ts
@@ -43,6 +43,9 @@ function parseArgs(args: readonly string[]): SmokeNpmLibOptions {
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === "--") {
+      continue;
+    }
     if (arg === "--root") {
       index += 1;
       root = requireArgumentValue(args[index], "--root");


### PR DESCRIPTION
The Release Manual rehearsal failed in Build npm Library Package with `Unsupported build:npm-lib argument: --`: the workflow calls `deno task build:npm-lib -- --out-dir ...` and deno task forwards the literal `--`, which these two parsers (unlike every other release script) did not skip. Verified with the exact workflow invocations locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)