### PR TITLE
feat: validate memory instrumentation + pending-heavy baseline tooling

### DIFF
--- a/scripts/generate-pending-heavy-mesh.ts
+++ b/scripts/generate-pending-heavy-mesh.ts
@@ -10,12 +10,14 @@ export interface GeneratePendingHeavyMeshOptions {
   outputPath: string;
   count: number;
   meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
+  termContentBytes?: number;
 }
 
 export interface GeneratePendingHeavyMeshResult {
   meshRoot: string;
   count: number;
   meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
+  termContentBytes: number;
   sourceDesignatorPath: string;
   extractedDesignatorPaths: readonly string[];
 }
@@ -27,6 +29,8 @@ export async function generatePendingHeavyMesh(
   options: GeneratePendingHeavyMeshOptions,
 ): Promise<GeneratePendingHeavyMeshResult> {
   assertPositiveInteger(options.count, "count");
+  const termContentBytes = options.termContentBytes ?? 0;
+  assertNonNegativeInteger(termContentBytes, "termContentBytes");
   const meshRoot = resolve(options.outputPath);
   await ensureEmptyOutputDirectory(meshRoot);
 
@@ -47,7 +51,7 @@ export async function generatePendingHeavyMesh(
   await executeWeave({ meshRoot });
   await Deno.writeTextFile(
     join(meshRoot, SOURCE_WORKING_FILE_PATH),
-    renderSourcePayload(meshBase, options.count),
+    renderSourcePayload(meshBase, options.count, termContentBytes),
   );
   await executeIntegrate({
     meshRoot,
@@ -77,21 +81,39 @@ export async function generatePendingHeavyMesh(
     meshRoot,
     count: options.count,
     meshInventoryHistoryPolicy: options.meshInventoryHistoryPolicy,
+    termContentBytes,
     sourceDesignatorPath: SOURCE_DESIGNATOR_PATH,
     extractedDesignatorPaths: extraction.extractedDesignatorPaths,
   };
 }
 
-function renderSourcePayload(meshBase: string, count: number): string {
+function renderSourcePayload(
+  meshBase: string,
+  count: number,
+  termContentBytes: number,
+): string {
   const terms = Array.from({ length: count }, (_, index) => {
     const ordinal = String(index + 1).padStart(6, "0");
-    return `<term-${ordinal}> a schema:DefinedTerm ;\n  schema:name "Term ${ordinal}" .`;
+    const description = termContentBytes === 0
+      ? ""
+      : ` ;\n  schema:description "${
+        deterministicTermContent(ordinal, termContentBytes)
+      }"`;
+    return `<term-${ordinal}> a schema:DefinedTerm ;\n  schema:name "Term ${ordinal}"${description} .`;
   });
   return `@base <${meshBase}> .
 @prefix schema: <https://schema.org/> .
 
 ${terms.join("\n\n")}
 `;
+}
+
+function deterministicTermContent(ordinal: string, bytes: number): string {
+  const prefix = `Term ${ordinal}:`;
+  if (bytes <= prefix.length) {
+    return prefix.slice(0, bytes);
+  }
+  return prefix + "x".repeat(bytes - prefix.length);
 }
 
 function meshInventoryConfigTurtle(
@@ -142,16 +164,24 @@ function assertPositiveInteger(value: number, name: string): void {
   }
 }
 
+function assertNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+}
+
 interface ParsedArgs {
   outputPath: string;
   count: number;
   meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
+  termContentBytes: number;
 }
 
 function parseArgs(args: readonly string[]): ParsedArgs {
   let outputPath: string | undefined;
   let count: number | undefined;
   let meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy = "current-only";
+  let termContentBytes = 0;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
@@ -176,6 +206,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       index += 1;
       continue;
     }
+    if (arg === "--term-content-bytes" && value !== undefined) {
+      termContentBytes = Number(value);
+      index += 1;
+      continue;
+    }
     throw new Error(`Unknown or incomplete argument: ${arg}`);
   }
 
@@ -186,7 +221,13 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     throw new Error("--count is required.");
   }
   assertPositiveInteger(count, "--count");
-  return { outputPath, count, meshInventoryHistoryPolicy };
+  assertNonNegativeInteger(termContentBytes, "--term-content-bytes");
+  return {
+    outputPath,
+    count,
+    meshInventoryHistoryPolicy,
+    termContentBytes,
+  };
 }
 
 if (import.meta.main) {
@@ -201,7 +242,7 @@ if (import.meta.main) {
           dirname(import.meta.filename!),
           "generate-pending-heavy-mesh.ts",
         )
-      } --output <empty-dir> --count <N> --mesh-inventory-history <current-only|versioned>`,
+      } --output <empty-dir> --count <N> --mesh-inventory-history <current-only|versioned> [--term-content-bytes <n>]`,
     );
     Deno.exit(1);
   }

--- a/scripts/generate-pending-heavy-mesh.ts
+++ b/scripts/generate-pending-heavy-mesh.ts
@@ -1,0 +1,208 @@
+import { dirname, join, resolve } from "@std/path";
+import { executeExtractAllTerms } from "../src/runtime/extract/extract.ts";
+import { executeIntegrate } from "../src/runtime/integrate/integrate.ts";
+import { executeMeshCreate } from "../src/runtime/mesh/create.ts";
+import { executeWeave } from "../src/runtime/weave/weave.ts";
+
+export type MeshInventoryHistoryPolicy = "current-only" | "versioned";
+
+export interface GeneratePendingHeavyMeshOptions {
+  outputPath: string;
+  count: number;
+  meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
+}
+
+export interface GeneratePendingHeavyMeshResult {
+  meshRoot: string;
+  count: number;
+  meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
+  sourceDesignatorPath: string;
+  extractedDesignatorPaths: readonly string[];
+}
+
+const SOURCE_DESIGNATOR_PATH = "source";
+const SOURCE_WORKING_FILE_PATH = "source.ttl";
+
+export async function generatePendingHeavyMesh(
+  options: GeneratePendingHeavyMeshOptions,
+): Promise<GeneratePendingHeavyMeshResult> {
+  assertPositiveInteger(options.count, "count");
+  const meshRoot = resolve(options.outputPath);
+  await ensureEmptyOutputDirectory(meshRoot);
+
+  const meshBase = `https://example.test/weave-memory-${crypto.randomUUID()}/`;
+  await executeMeshCreate({
+    workspaceRoot: meshRoot,
+    request: {
+      meshBase,
+      publicationProfile: "none",
+    },
+  });
+
+  await Deno.writeTextFile(
+    join(meshRoot, "_mesh/_config/config.ttl"),
+    meshInventoryConfigTurtle(options.meshInventoryHistoryPolicy),
+  );
+
+  await executeWeave({ meshRoot });
+  await Deno.writeTextFile(
+    join(meshRoot, SOURCE_WORKING_FILE_PATH),
+    renderSourcePayload(meshBase, options.count),
+  );
+  await executeIntegrate({
+    meshRoot,
+    request: {
+      designatorPath: SOURCE_DESIGNATOR_PATH,
+      source: SOURCE_WORKING_FILE_PATH,
+    },
+  });
+  await executeWeave({
+    meshRoot,
+    request: {
+      targets: [{ designatorPath: SOURCE_DESIGNATOR_PATH }],
+    },
+  });
+
+  const extraction = await executeExtractAllTerms({
+    meshRoot,
+    request: { sourceDesignatorPath: SOURCE_DESIGNATOR_PATH },
+  });
+  if (extraction.extractedDesignatorPaths.length !== options.count) {
+    throw new Error(
+      `Expected ${options.count} extracted terms, but created ${extraction.extractedDesignatorPaths.length}.`,
+    );
+  }
+
+  return {
+    meshRoot,
+    count: options.count,
+    meshInventoryHistoryPolicy: options.meshInventoryHistoryPolicy,
+    sourceDesignatorPath: SOURCE_DESIGNATOR_PATH,
+    extractedDesignatorPaths: extraction.extractedDesignatorPaths,
+  };
+}
+
+function renderSourcePayload(meshBase: string, count: number): string {
+  const terms = Array.from({ length: count }, (_, index) => {
+    const ordinal = String(index + 1).padStart(6, "0");
+    return `<term-${ordinal}> a schema:DefinedTerm ;\n  schema:name "Term ${ordinal}" .`;
+  });
+  return `@base <${meshBase}> .
+@prefix schema: <https://schema.org/> .
+
+${terms.join("\n\n")}
+`;
+}
+
+function meshInventoryConfigTurtle(
+  policy: MeshInventoryHistoryPolicy,
+): string {
+  const policyLocalName = policy === "versioned"
+    ? "historyTrackingPolicy_versioned"
+    : "historyTrackingPolicy_currentOnly";
+  return `@prefix sfcfg: <https://semantic-flow.github.io/sflo/config/> .
+
+<> a sfcfg:MeshConfig ;
+  sfcfg:hasPublicationProfile sfcfg:publicationProfile_none ;
+  sfcfg:hasPolicyBinding <#mesh-inventory-history> .
+
+<#mesh-inventory-history> a sfcfg:PolicyBinding ;
+  sfcfg:bindsPolicy <#history-policy> ;
+  sfcfg:appliesToPolicyTarget <#mesh-inventory> .
+
+<#history-policy> a sfcfg:PolicyDefinition ;
+  sfcfg:hasHistoryTrackingPolicy sfcfg:${policyLocalName} .
+
+<#mesh-inventory> a sfcfg:ArtifactRolePolicyTarget ;
+  sfcfg:hasArtifactRole sfcfg:artifactRole_meshInventory .
+`;
+}
+
+async function ensureEmptyOutputDirectory(path: string): Promise<void> {
+  try {
+    const stat = await Deno.stat(path);
+    if (!stat.isDirectory) {
+      throw new Error(`Output path exists and is not a directory: ${path}`);
+    }
+    for await (const _entry of Deno.readDir(path)) {
+      throw new Error(`Output directory must be empty: ${path}`);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      await Deno.mkdir(path, { recursive: true });
+      return;
+    }
+    throw error;
+  }
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+}
+
+interface ParsedArgs {
+  outputPath: string;
+  count: number;
+  meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
+}
+
+function parseArgs(args: readonly string[]): ParsedArgs {
+  let outputPath: string | undefined;
+  let count: number | undefined;
+  let meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy = "current-only";
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    const value = args[index + 1];
+    if (arg === "--output" && value !== undefined) {
+      outputPath = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--count" && value !== undefined) {
+      count = Number(value);
+      index += 1;
+      continue;
+    }
+    if (arg === "--mesh-inventory-history" && value !== undefined) {
+      if (value !== "current-only" && value !== "versioned") {
+        throw new Error(
+          "--mesh-inventory-history must be current-only or versioned.",
+        );
+      }
+      meshInventoryHistoryPolicy = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown or incomplete argument: ${arg}`);
+  }
+
+  if (outputPath === undefined) {
+    throw new Error("--output is required.");
+  }
+  if (count === undefined) {
+    throw new Error("--count is required.");
+  }
+  assertPositiveInteger(count, "--count");
+  return { outputPath, count, meshInventoryHistoryPolicy };
+}
+
+if (import.meta.main) {
+  try {
+    const result = await generatePendingHeavyMesh(parseArgs(Deno.args));
+    console.log(JSON.stringify(result));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error(
+      `Usage: deno run -A ${
+        resolve(
+          dirname(import.meta.filename!),
+          "generate-pending-heavy-mesh.ts",
+        )
+      } --output <empty-dir> --count <N> --mesh-inventory-history <current-only|versioned>`,
+    );
+    Deno.exit(1);
+  }
+}

--- a/src/runtime/weave/memory_stats.ts
+++ b/src/runtime/weave/memory_stats.ts
@@ -49,6 +49,7 @@ export interface RuntimeMemoryStatsReport
   command: string;
   v8Heap: {
     usedHeapSize: number;
+    postGcUsedHeapSize: number | null;
     heapSizeLimit: number;
   };
 }
@@ -122,15 +123,24 @@ class EnabledRuntimeMemoryStats implements RuntimeMemoryStats {
     }
     this.#finished = true;
     const { getHeapStatistics } = await import("node:v8");
-    const heap = getHeapStatistics();
+    const preGcHeap = getHeapStatistics();
+    const gc = (
+      globalThis as typeof globalThis & { gc?: () => void }
+    ).gc;
+    let postGcUsedHeapSize: number | null = null;
+    if (typeof gc === "function") {
+      gc();
+      postGcUsedHeapSize = getHeapStatistics().used_heap_size;
+    }
     const report: RuntimeMemoryStatsReport = {
       command: this.#command,
       ...this.#retainedState,
       planningLoopIterations: this.#planningLoopIterations,
       maxRssBytes: this.#maxRssBytes,
       v8Heap: {
-        usedHeapSize: heap.used_heap_size,
-        heapSizeLimit: heap.heap_size_limit,
+        usedHeapSize: preGcHeap.used_heap_size,
+        postGcUsedHeapSize,
+        heapSizeLimit: preGcHeap.heap_size_limit,
       },
     };
     console.error(`[memory-stats] ${JSON.stringify(report)}`);

--- a/src/runtime/weave/memory_stats.ts
+++ b/src/runtime/weave/memory_stats.ts
@@ -1,0 +1,235 @@
+import type { PlannedFile } from "../../core/planned_file.ts";
+import type {
+  TextFileOverlay,
+  TextFileOverlayRetainedMemoryStats,
+} from "./planning_context.ts";
+
+const MEMORY_STATS_ENV_VAR = "WEAVE_MEMORY_STATS";
+
+export type CreatedFilePathClassification =
+  | "meshInventoryHistorySnapshots"
+  | "knopInventoriesAndMetadata"
+  | "payloadSnapshots"
+  | "other";
+
+export interface RetainedFileStats {
+  count: number;
+  bytes: number;
+}
+
+export interface VersionExecutionRetainedMemoryStats {
+  createdFiles: RetainedFileStats & {
+    byPathClassification: Record<
+      CreatedFilePathClassification,
+      RetainedFileStats
+    >;
+  };
+  updatedFileByPath: RetainedFileStats;
+  overlayStaged: {
+    entries: number;
+    bytes: number;
+  };
+  readCache: {
+    entries: number;
+    bytes: number;
+    hits: number;
+  };
+  candidateCache: {
+    entries: number;
+    approximateRetainedBytes: number;
+    stores: number;
+    invalidations: number;
+  };
+  planningLoopIterations: number;
+  maxRssBytes: number;
+}
+
+export interface RuntimeMemoryStatsReport
+  extends VersionExecutionRetainedMemoryStats {
+  command: string;
+  v8Heap: {
+    usedHeapSize: number;
+    heapSizeLimit: number;
+  };
+}
+
+export interface RuntimeMemoryStats {
+  samplePlanningLoopIteration(): void;
+  captureVersionExecutionRetainedState(
+    createdFiles: readonly PlannedFile[],
+    updatedFiles: ReadonlyMap<string, PlannedFile>,
+    overlay: TextFileOverlay,
+  ): void;
+  finish(): Promise<void>;
+}
+
+class EnabledRuntimeMemoryStats implements RuntimeMemoryStats {
+  readonly #command: string;
+  #finished = false;
+  #planningLoopIterations = 0;
+  #maxRssBytes = 0;
+  #retainedState = emptyRetainedState();
+
+  constructor(command: string) {
+    this.#command = command;
+  }
+
+  samplePlanningLoopIteration(): void {
+    this.#planningLoopIterations += 1;
+    if (typeof Deno.memoryUsage === "function") {
+      this.#maxRssBytes = Math.max(
+        this.#maxRssBytes,
+        Deno.memoryUsage().rss,
+      );
+    }
+  }
+
+  captureVersionExecutionRetainedState(
+    createdFiles: readonly PlannedFile[],
+    updatedFiles: ReadonlyMap<string, PlannedFile>,
+    overlay: TextFileOverlay,
+  ): void {
+    const encoder = new TextEncoder();
+    const createdStats = emptyCreatedFileStats();
+    for (const file of createdFiles) {
+      const bytes = encoder.encode(file.contents).byteLength;
+      createdStats.count += 1;
+      createdStats.bytes += bytes;
+      const classification = classifyCreatedFilePath(file.path);
+      createdStats.byPathClassification[classification].count += 1;
+      createdStats.byPathClassification[classification].bytes += bytes;
+    }
+
+    const updatedStats: RetainedFileStats = { count: 0, bytes: 0 };
+    for (const file of updatedFiles.values()) {
+      updatedStats.count += 1;
+      updatedStats.bytes += encoder.encode(file.contents).byteLength;
+    }
+
+    const overlayStats = overlay.retainedMemoryStats();
+    this.#retainedState = {
+      createdFiles: createdStats,
+      updatedFileByPath: updatedStats,
+      ...toReportedOverlayStats(overlayStats),
+      planningLoopIterations: this.#planningLoopIterations,
+      maxRssBytes: this.#maxRssBytes,
+    };
+  }
+
+  async finish(): Promise<void> {
+    if (this.#finished) {
+      return;
+    }
+    this.#finished = true;
+    const { getHeapStatistics } = await import("node:v8");
+    const heap = getHeapStatistics();
+    const report: RuntimeMemoryStatsReport = {
+      command: this.#command,
+      ...this.#retainedState,
+      planningLoopIterations: this.#planningLoopIterations,
+      maxRssBytes: this.#maxRssBytes,
+      v8Heap: {
+        usedHeapSize: heap.used_heap_size,
+        heapSizeLimit: heap.heap_size_limit,
+      },
+    };
+    console.error(`[memory-stats] ${JSON.stringify(report)}`);
+  }
+}
+
+export function createRuntimeMemoryStats(
+  command: string,
+): RuntimeMemoryStats | undefined {
+  return isRuntimeMemoryStatsEnabled()
+    ? new EnabledRuntimeMemoryStats(command)
+    : undefined;
+}
+
+export function classifyCreatedFilePath(
+  path: string,
+): CreatedFilePathClassification {
+  const normalized = path.replaceAll("\\", "/");
+  if (
+    /^_mesh\/_inventory\/_history[^/]+\/_s[^/]+\//.test(normalized)
+  ) {
+    return "meshInventoryHistorySnapshots";
+  }
+  if (/(?:^|\/)_knop\/_(?:inventory|meta)(?:\/|$)/.test(normalized)) {
+    return "knopInventoriesAndMetadata";
+  }
+  if (/(?:^|\/)_history[^/]+\/_s[^/]+\//.test(normalized)) {
+    return "payloadSnapshots";
+  }
+  return "other";
+}
+
+function isRuntimeMemoryStatsEnabled(): boolean {
+  let value: string | undefined;
+  try {
+    value = Deno.env.get(MEMORY_STATS_ENV_VAR);
+  } catch {
+    return false;
+  }
+
+  const normalized = value?.trim().toLowerCase();
+  return normalized !== undefined &&
+    normalized.length > 0 &&
+    !["0", "false", "no", "off"].includes(normalized);
+}
+
+function emptyRetainedState(): VersionExecutionRetainedMemoryStats {
+  return {
+    createdFiles: emptyCreatedFileStats(),
+    updatedFileByPath: { count: 0, bytes: 0 },
+    overlayStaged: { entries: 0, bytes: 0 },
+    readCache: { entries: 0, bytes: 0, hits: 0 },
+    candidateCache: {
+      entries: 0,
+      approximateRetainedBytes: 0,
+      stores: 0,
+      invalidations: 0,
+    },
+    planningLoopIterations: 0,
+    maxRssBytes: 0,
+  };
+}
+
+function emptyCreatedFileStats(): VersionExecutionRetainedMemoryStats[
+  "createdFiles"
+] {
+  return {
+    count: 0,
+    bytes: 0,
+    byPathClassification: {
+      meshInventoryHistorySnapshots: { count: 0, bytes: 0 },
+      knopInventoriesAndMetadata: { count: 0, bytes: 0 },
+      payloadSnapshots: { count: 0, bytes: 0 },
+      other: { count: 0, bytes: 0 },
+    },
+  };
+}
+
+function toReportedOverlayStats(
+  stats: TextFileOverlayRetainedMemoryStats,
+): Pick<
+  VersionExecutionRetainedMemoryStats,
+  "overlayStaged" | "readCache" | "candidateCache"
+> {
+  return {
+    overlayStaged: {
+      entries: stats.stagedEntries,
+      bytes: stats.stagedBytes,
+    },
+    readCache: {
+      entries: stats.readCacheEntries,
+      bytes: stats.readCacheBytes,
+      hits: stats.readCacheHits,
+    },
+    candidateCache: {
+      entries: stats.candidateCacheEntries,
+      approximateRetainedBytes: stats.candidateCacheApproxRetainedBytes,
+      stores: stats.candidateCacheStores,
+      invalidations: stats.candidateCacheInvalidations,
+    },
+  };
+}

--- a/src/runtime/weave/memory_stats_test.ts
+++ b/src/runtime/weave/memory_stats_test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import { classifyCreatedFilePath } from "./memory_stats.ts";
+
+Deno.test("classifyCreatedFilePath separates retained validation plan roles", () => {
+  assertEquals(
+    classifyCreatedFilePath(
+      "_mesh/_inventory/_history001/_s0002/ttl/inventory.ttl",
+    ),
+    "meshInventoryHistorySnapshots",
+  );
+  assertEquals(
+    classifyCreatedFilePath(
+      "term/_knop/_inventory/_history001/_s0001/ttl/inventory.ttl",
+    ),
+    "knopInventoriesAndMetadata",
+  );
+  assertEquals(
+    classifyCreatedFilePath(
+      "term/_knop/_meta/_history001/_s0001/ttl/meta.ttl",
+    ),
+    "knopInventoriesAndMetadata",
+  );
+  assertEquals(
+    classifyCreatedFilePath("term/_history001/_s0001/ttl/term.ttl"),
+    "payloadSnapshots",
+  );
+  assertEquals(
+    classifyCreatedFilePath("term/index.html"),
+    "other",
+  );
+});

--- a/src/runtime/weave/planning_context.ts
+++ b/src/runtime/weave/planning_context.ts
@@ -98,21 +98,17 @@ export class TextFileOverlay extends Map<string, string> {
   }
 
   retainedMemoryStats(): TextFileOverlayRetainedMemoryStats {
-    const encoder = new TextEncoder();
     return {
       stagedEntries: this.size,
-      stagedBytes: sumTextBytes(this.values(), encoder),
+      stagedBytes: sumTextBytes(this.values()),
       readCacheEntries: this.#readCache.size,
-      readCacheBytes: sumTextBytes(this.#readCache.values(), encoder),
+      readCacheBytes: sumTextBytes(this.#readCache.values()),
       readCacheHits: this.cacheHitCount,
       candidateCacheEntries: this.#candidateCache.size,
       candidateCacheApproxRetainedBytes: [...this.#candidateCache.values()]
         .reduce(
           (total, entry) =>
-            total + approximateCandidateRetainedBytes(
-              entry.candidate,
-              encoder,
-            ),
+            total + approximateCandidateRetainedBytes(entry.candidate),
           0,
         ),
       candidateCacheStores: this.candidateCacheStoreCount,
@@ -136,20 +132,20 @@ export class TextFileOverlay extends Map<string, string> {
   }
 }
 
-function sumTextBytes(
-  values: Iterable<string>,
-  encoder: TextEncoder,
-): number {
+// A shared value instead of a TextEncoder-typed parameter: dnt's Node type
+// checking has no global TextEncoder type, only the shimmed value.
+const RETAINED_BYTES_ENCODER = new TextEncoder();
+
+function sumTextBytes(values: Iterable<string>): number {
   let total = 0;
   for (const value of values) {
-    total += encoder.encode(value).byteLength;
+    total += RETAINED_BYTES_ENCODER.encode(value).byteLength;
   }
   return total;
 }
 
 function approximateCandidateRetainedBytes(
   candidate: WeaveableKnopCandidate | undefined,
-  encoder: TextEncoder,
 ): number {
   if (candidate === undefined) {
     return 0;
@@ -160,7 +156,7 @@ function approximateCandidateRetainedBytes(
   const visit = (value: unknown, fieldName = ""): void => {
     if (typeof value === "string") {
       if (/(?:turtle|text)$/i.test(fieldName)) {
-        total += encoder.encode(value).byteLength;
+        total += RETAINED_BYTES_ENCODER.encode(value).byteLength;
       }
       return;
     }

--- a/src/runtime/weave/planning_context.ts
+++ b/src/runtime/weave/planning_context.ts
@@ -11,6 +11,18 @@ interface CandidateCacheEntry {
   dependencyPaths: ReadonlySet<string>;
 }
 
+export interface TextFileOverlayRetainedMemoryStats {
+  stagedEntries: number;
+  stagedBytes: number;
+  readCacheEntries: number;
+  readCacheBytes: number;
+  readCacheHits: number;
+  candidateCacheEntries: number;
+  candidateCacheApproxRetainedBytes: number;
+  candidateCacheStores: number;
+  candidateCacheInvalidations: number;
+}
+
 export class TextFileOverlay extends Map<string, string> {
   #readCache = new Map<string, string>();
   #candidateCache = new Map<string, CandidateCacheEntry>();
@@ -85,6 +97,29 @@ export class TextFileOverlay extends Map<string, string> {
     this.#invalidateCandidates(stagedPaths);
   }
 
+  retainedMemoryStats(): TextFileOverlayRetainedMemoryStats {
+    const encoder = new TextEncoder();
+    return {
+      stagedEntries: this.size,
+      stagedBytes: sumTextBytes(this.values(), encoder),
+      readCacheEntries: this.#readCache.size,
+      readCacheBytes: sumTextBytes(this.#readCache.values(), encoder),
+      readCacheHits: this.cacheHitCount,
+      candidateCacheEntries: this.#candidateCache.size,
+      candidateCacheApproxRetainedBytes: [...this.#candidateCache.values()]
+        .reduce(
+          (total, entry) =>
+            total + approximateCandidateRetainedBytes(
+              entry.candidate,
+              encoder,
+            ),
+          0,
+        ),
+      candidateCacheStores: this.candidateCacheStoreCount,
+      candidateCacheInvalidations: this.candidateCacheInvalidationCount,
+    };
+  }
+
   #invalidateCandidates(stagedPaths: readonly string[]): void {
     if (stagedPaths.length === 0 || this.#candidateCache.size === 0) {
       return;
@@ -99,6 +134,52 @@ export class TextFileOverlay extends Map<string, string> {
       }
     }
   }
+}
+
+function sumTextBytes(
+  values: Iterable<string>,
+  encoder: TextEncoder,
+): number {
+  let total = 0;
+  for (const value of values) {
+    total += encoder.encode(value).byteLength;
+  }
+  return total;
+}
+
+function approximateCandidateRetainedBytes(
+  candidate: WeaveableKnopCandidate | undefined,
+  encoder: TextEncoder,
+): number {
+  if (candidate === undefined) {
+    return 0;
+  }
+
+  let total = 0;
+  const visited = new Set<object>();
+  const visit = (value: unknown, fieldName = ""): void => {
+    if (typeof value === "string") {
+      if (/(?:turtle|text)$/i.test(fieldName)) {
+        total += encoder.encode(value).byteLength;
+      }
+      return;
+    }
+    if (value instanceof Uint8Array) {
+      if (/bytes$/i.test(fieldName)) {
+        total += value.byteLength;
+      }
+      return;
+    }
+    if (value === null || typeof value !== "object" || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+    for (const [key, nestedValue] of Object.entries(value)) {
+      visit(nestedValue, key);
+    }
+  };
+  visit(candidate);
+  return total;
 }
 
 export function applyPlannedFilesToOverlay(

--- a/src/runtime/weave/version_execution.ts
+++ b/src/runtime/weave/version_execution.ts
@@ -63,6 +63,7 @@ import {
   applyPlannedFilesToOverlay,
   TextFileOverlay,
 } from "./planning_context.ts";
+import type { RuntimeMemoryStats } from "./memory_stats.ts";
 import type { WeaveProgressHandler } from "./progress.ts";
 import { timeOptional, timeOptionalSync } from "./timing_helpers.ts";
 import { toWorkspaceRelativePath } from "./workspace_paths.ts";
@@ -269,6 +270,7 @@ export async function prepareVersionExecution(
     meshState: MeshState,
     designatorPaths: readonly string[],
   ) => void,
+  memoryStats?: RuntimeMemoryStats,
 ): Promise<PreparedVersionExecution> {
   await timeOptional(
     timing,
@@ -639,6 +641,7 @@ export async function prepareVersionExecution(
       total: initialWeaveableKnops.length,
       percent: Math.round((completed / initialWeaveableKnops.length) * 100),
     });
+    memoryStats?.samplePlanningLoopIteration();
   }
 
   const plan: VersionPlan = {
@@ -657,6 +660,11 @@ export async function prepareVersionExecution(
   timing?.setField(
     "candidateCacheInvalidations",
     overlay.candidateCacheInvalidationCount,
+  );
+  memoryStats?.captureVersionExecutionRetainedState(
+    createdFiles,
+    updatedFileByPath,
+    overlay,
   );
 
   return {

--- a/src/runtime/weave/weave.ts
+++ b/src/runtime/weave/weave.ts
@@ -48,6 +48,7 @@ import {
 import { type HistoryTrackingPolicy } from "../config/effective_config.ts";
 import { validatePublicationPreset } from "../publication/presets.ts";
 import { InventoryResolutionError } from "../mesh/inventory.ts";
+import { createRuntimeMemoryStats } from "./memory_stats.ts";
 
 export interface ExecuteValidateOptions {
   meshRoot: string;
@@ -151,6 +152,7 @@ export async function executeValidate(
 ): Promise<ValidateResult> {
   const scope = options.scope ?? "mesh";
   const timing = createRuntimeTiming(`validate.${scope}`);
+  const memoryStats = createRuntimeMemoryStats(`validate.${scope}`);
   let status = "succeeded";
   let observedMeshBase: string | undefined;
   let knownDesignatorPathCount = 0;
@@ -210,6 +212,7 @@ export async function executeValidate(
           assertTargetsAreKnown(targets, designatorPaths);
         }
       },
+      memoryStats,
     );
     timing.timeSync("validateRdf", () => validateVersionPlanRdf(prepared.plan));
     const publicationValidation = await timing.time(
@@ -284,6 +287,7 @@ export async function executeValidate(
     throw error;
   } finally {
     timing.finish({ status });
+    await memoryStats?.finish();
   }
 }
 

--- a/tests/scripts/pending_heavy_mesh_test.ts
+++ b/tests/scripts/pending_heavy_mesh_test.ts
@@ -42,12 +42,20 @@ Deno.test("pending-heavy generator enters the instrumented recursive validation 
   assertGreater(currentReport.candidateCache.invalidations, 0);
   assertGreater(currentReport.maxRssBytes, 0);
   assertGreater(currentReport.v8Heap.usedHeapSize, 0);
+  assertEquals(currentReport.v8Heap.postGcUsedHeapSize, null);
   assertGreater(currentReport.v8Heap.heapSizeLimit, 0);
   assertEquals(
     currentReport.createdFiles.byPathClassification
       .meshInventoryHistorySnapshots.count,
     0,
   );
+
+  const gcEnabled = await runValidate(currentOnlyRoot, "1", true);
+  assert(gcEnabled.output.success, gcEnabled.stderr);
+  const gcReport = parseMemoryStats(gcEnabled.stderr);
+  assertEquals(gcReport.planningLoopIterations, 3);
+  assertGreater(gcReport.v8Heap.usedHeapSize, 0);
+  assertGreater(gcReport.v8Heap.postGcUsedHeapSize!, 0);
 
   const disabled = await runValidate(currentOnlyRoot, "0");
   assert(disabled.output.success, disabled.stderr);
@@ -86,13 +94,44 @@ Deno.test("pending-heavy generator materializes mesh-inventory history when requ
   );
 });
 
+Deno.test("pending-heavy generator adds deterministic per-term content", async () => {
+  const meshRoot = await createTestTmpDir(
+    "weave-pending-heavy-content-",
+  );
+  const generated = await generatePendingHeavyMesh({
+    outputPath: meshRoot,
+    count: 2,
+    meshInventoryHistoryPolicy: "current-only",
+    termContentBytes: 128,
+  });
+  assertEquals(generated.termContentBytes, 128);
+
+  const source = await Deno.readTextFile(join(meshRoot, "source.ttl"));
+  assert(
+    source.includes(
+      `schema:description "Term 000001:${"x".repeat(116)}"`,
+    ),
+  );
+  assert(
+    source.includes(
+      `schema:description "Term 000002:${"x".repeat(116)}"`,
+    ),
+  );
+
+  const enabled = await runValidate(meshRoot, "1");
+  assert(enabled.output.success, enabled.stderr);
+  assertEquals(parseMemoryStats(enabled.stderr).planningLoopIterations, 2);
+});
+
 async function runValidate(
   meshRoot: string,
   memoryStatsValue: string,
+  exposeGc = false,
 ): Promise<{ output: Deno.CommandOutput; stderr: string }> {
   const output = await new Deno.Command(Deno.execPath(), {
     args: [
       "run",
+      ...(exposeGc ? ["--v8-flags=--expose-gc"] : []),
       "-A",
       cliEntrypoint,
       "validate",

--- a/tests/scripts/pending_heavy_mesh_test.ts
+++ b/tests/scripts/pending_heavy_mesh_test.ts
@@ -1,0 +1,121 @@
+import { assert, assertEquals, assertGreater } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import {
+  generatePendingHeavyMesh,
+} from "../../scripts/generate-pending-heavy-mesh.ts";
+import type { RuntimeMemoryStatsReport } from "../../src/runtime/weave/memory_stats.ts";
+import { createTestTmpDir } from "../support/test_tmp.ts";
+
+const repoRoot = fromFileUrl(new URL("../../", import.meta.url));
+const cliEntrypoint = join(repoRoot, "src/main.ts");
+
+Deno.test("pending-heavy generator enters the instrumented recursive validation loop", async () => {
+  const currentOnlyRoot = await createTestTmpDir(
+    "weave-pending-heavy-current-only-",
+  );
+  const currentOnly = await generatePendingHeavyMesh({
+    outputPath: currentOnlyRoot,
+    count: 3,
+    meshInventoryHistoryPolicy: "current-only",
+  });
+  assertEquals(currentOnly.extractedDesignatorPaths.length, 3);
+
+  const enabled = await runValidate(currentOnlyRoot, "1");
+  assert(enabled.output.success, enabled.stderr);
+  const currentReport = parseMemoryStats(enabled.stderr);
+  assertEquals(currentReport.planningLoopIterations, 3);
+  assertEquals(currentReport.createdFiles.count, 0);
+  assertEquals(currentReport.createdFiles.bytes, 0);
+  assertGreater(currentReport.updatedFileByPath.count, 0);
+  assertGreater(currentReport.updatedFileByPath.bytes, 0);
+  assertGreater(currentReport.overlayStaged.entries, 0);
+  assertGreater(currentReport.overlayStaged.bytes, 0);
+  assertGreater(currentReport.readCache.entries, 0);
+  assertGreater(currentReport.readCache.bytes, 0);
+  assertGreater(currentReport.readCache.hits, 0);
+  assertGreater(currentReport.candidateCache.entries, 0);
+  assertEquals(
+    currentReport.candidateCache.approximateRetainedBytes,
+    0,
+  );
+  assertGreater(currentReport.candidateCache.stores, 0);
+  assertGreater(currentReport.candidateCache.invalidations, 0);
+  assertGreater(currentReport.maxRssBytes, 0);
+  assertGreater(currentReport.v8Heap.usedHeapSize, 0);
+  assertGreater(currentReport.v8Heap.heapSizeLimit, 0);
+  assertEquals(
+    currentReport.createdFiles.byPathClassification
+      .meshInventoryHistorySnapshots.count,
+    0,
+  );
+
+  const disabled = await runValidate(currentOnlyRoot, "0");
+  assert(disabled.output.success, disabled.stderr);
+  assertEquals(disabled.stderr.includes("[memory-stats]"), false);
+});
+
+Deno.test("pending-heavy generator materializes mesh-inventory history when requested", async () => {
+  const versionedRoot = await createTestTmpDir(
+    "weave-pending-heavy-versioned-",
+  );
+  const generated = await generatePendingHeavyMesh({
+    outputPath: versionedRoot,
+    count: 2,
+    meshInventoryHistoryPolicy: "versioned",
+  });
+  assertEquals(generated.extractedDesignatorPaths.length, 2);
+  assert(
+    (await Deno.readTextFile(
+      join(versionedRoot, "_mesh/_config/config.ttl"),
+    )).includes("sfcfg:historyTrackingPolicy_versioned"),
+  );
+
+  const enabled = await runValidate(versionedRoot, "1");
+  assert(enabled.output.success, enabled.stderr);
+  const report = parseMemoryStats(enabled.stderr);
+  assertEquals(report.planningLoopIterations, 2);
+  assertGreater(
+    report.createdFiles.byPathClassification
+      .meshInventoryHistorySnapshots.count,
+    0,
+  );
+  assertGreater(
+    report.createdFiles.byPathClassification
+      .meshInventoryHistorySnapshots.bytes,
+    0,
+  );
+});
+
+async function runValidate(
+  meshRoot: string,
+  memoryStatsValue: string,
+): Promise<{ output: Deno.CommandOutput; stderr: string }> {
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "-A",
+      cliEntrypoint,
+      "validate",
+      "mesh",
+      "--mesh-root",
+      meshRoot,
+    ],
+    cwd: repoRoot,
+    env: { WEAVE_MEMORY_STATS: memoryStatsValue },
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    output,
+    stderr: new TextDecoder().decode(output.stderr),
+  };
+}
+
+function parseMemoryStats(stderr: string): RuntimeMemoryStatsReport {
+  const prefix = "[memory-stats] ";
+  const line = stderr.split("\n").find((candidate) =>
+    candidate.startsWith(prefix)
+  );
+  assert(line !== undefined, stderr);
+  return JSON.parse(line.slice(prefix.length)) as RuntimeMemoryStatsReport;
+}


### PR DESCRIPTION
## Summary

The instrumentation/attribution phase of the whole-mesh validate bounded-memory task (archive note `wa.task.2026.2026-07-29_1220-whole-mesh-validate-bounded-memory`, build + adversarial-review receipts inside). Rebased onto main after #25; the two-file overlap (`weave.ts`, `version_execution.ts`) reconciled so the classified validate path carries the optional `memoryStats` wiring.

- `feat(validate): instrument retained memory` — opt-in `WEAVE_MEMORY_STATS=1` JSON on stderr: retained bytes by role (created plan text by path class, updated map, overlay staged, read cache, candidate cache), planner loop iterations, peak RSS, V8 heap stats. Zero work when unset; `node:v8` imported dynamically at finish only; fs-purity guard green.
- `test(validate): add pending-heavy baseline mesh` — `scripts/generate-pending-heavy-mesh.ts`: self-contained generator for meshes with N pending extracted-term Knops (policy- and content-parameterized, no fixture-repo refs); honesty test proves untargeted validate performs exactly N recursive iterations.
- `feat(validate): discriminate retained memory after gc` — `postGcUsedHeapSize` under `--v8-flags=--expose-gc`; `--term-content-bytes` knob.

## Evidence this tooling produced (receipts in the archive note)

- Reproduced the consumer-reported untargeted-validate heap exhaustion as a benchmark: N=1700 pending Knops at ~1 KB/term content hits V8's default ~4.09 GiB ceiling in 14 s (4.14 GiB peak RSS).
- Attributed the mechanism: per-candidate full-source duplication dominates content-carrying meshes; content-0 runs are pure parse churn (post-GC heap collapses to ~15 MB at N=1700).

No behavior changes to validation semantics; instrumentation is inert unless `WEAVE_MEMORY_STATS` is set.

## Test evidence

Full `env -u NO_COLOR deno task ci`: **737 passed / 0 failed** on the rebased tip; focused memory-stats + generator honesty suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)