### PR TITLE
fix(validate): share payload text across candidates — kills the srd-scale 4 GiB validate exhaustion

### DIFF
--- a/src/runtime/artifact_resolution/resolver.ts
+++ b/src/runtime/artifact_resolution/resolver.ts
@@ -19,6 +19,7 @@ import {
   resolveAllowedLocalPath,
 } from "../operational/local_path_policy.ts";
 import { resolveRepositorySourceFloatingLocalPath } from "../operational/repository_source.ts";
+import { readTextFileWithOverlay } from "../weave/planning_context.ts";
 import type {
   ArtifactResolutionContentMode,
   ArtifactResolutionContext,
@@ -686,6 +687,16 @@ async function resultForResolvedPath(
   const bytes = await readResolvedBytes(context, absolutePath, request);
   const contentDigest = await sha256Digest(bytes);
   verifyExpectedDigest(request, contentDigest);
+  const decodedText = contentMode === "text"
+    ? decodeUtf8(bytes, request)
+    : undefined;
+  const sharedText = decodedText === undefined
+    ? undefined
+    : await readTextFileWithOverlay(
+      absolutePath,
+      context.overlay,
+      decodedText,
+    );
   return {
     requested: request,
     observed: {
@@ -694,7 +705,7 @@ async function resultForResolvedPath(
     },
     content: {
       bytes,
-      ...(contentMode === "text" ? { text: decodeUtf8(bytes, request) } : {}),
+      ...(sharedText === undefined ? {} : { text: sharedText }),
     },
   };
 }
@@ -1076,7 +1087,7 @@ async function loadTargetArtifactInventory(
     toKnopPath(target.designatorPath),
     "_inventory/inventory.ttl",
   );
-  const turtle = await readTextFile(context.overlay, inventoryPath, request);
+  const turtle = await readTextFile(inventoryPath, context.overlay, request);
   let quads: Quad[];
   try {
     quads = new Parser({ baseIRI: context.meshBase }).parse(turtle);
@@ -1147,16 +1158,12 @@ function describeSupportedTargetArtifact(
 }
 
 async function readTextFile(
-  overlay: ReadonlyMap<string, string> | undefined,
   path: string,
+  overlay: ReadonlyMap<string, string> | undefined,
   request: ArtifactResolutionRequest,
 ): Promise<string> {
-  const staged = overlay?.get(path);
-  if (staged !== undefined) {
-    return staged;
-  }
   try {
-    return await Deno.readTextFile(path);
+    return await readTextFileWithOverlay(path, overlay);
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
       throw new ArtifactResolutionError(

--- a/src/runtime/weave/artifact_loaders.ts
+++ b/src/runtime/weave/artifact_loaders.ts
@@ -103,10 +103,17 @@ export async function loadPayloadWorkingArtifact(
           "workingLocalRelativePath",
           workingLocalRelativePath,
         );
-    const currentPayload = await readPayloadFileWithOverlay(
-      absoluteCurrentPayloadPath,
-      overlay,
-    );
+    const currentPayload = isTextLikePayloadPath(workingLocalRelativePath)
+      ? {
+        text: await readTextFileWithOverlay(
+          absoluteCurrentPayloadPath,
+          overlay,
+        ),
+      }
+      : await readBinaryPayloadFileWithOverlay(
+        absoluteCurrentPayloadPath,
+        overlay,
+      );
     currentPayloadTurtle = currentPayload.text;
     currentPayloadBytes = isTextLikePayloadPath(workingLocalRelativePath)
       ? undefined
@@ -131,17 +138,21 @@ export async function loadPayloadWorkingArtifact(
 
   if (latestHistoricalSnapshotPath) {
     try {
-      const latestHistoricalSnapshot = await readPayloadFileWithOverlay(
-        resolveAllowedLocalPath(
-          localPathPolicy,
-          "workingLocalRelativePath",
-          latestHistoricalSnapshotPath,
-        ),
-        overlay,
+      const absoluteLatestHistoricalSnapshotPath = resolveAllowedLocalPath(
+        localPathPolicy,
+        "workingLocalRelativePath",
+        latestHistoricalSnapshotPath,
       );
       if (isTextLikePayloadPath(latestHistoricalSnapshotPath)) {
-        latestHistoricalSnapshotTurtle = latestHistoricalSnapshot.text;
+        latestHistoricalSnapshotTurtle = await readTextFileWithOverlay(
+          absoluteLatestHistoricalSnapshotPath,
+          overlay,
+        );
       } else {
+        const latestHistoricalSnapshot = await readBinaryPayloadFileWithOverlay(
+          absoluteLatestHistoricalSnapshotPath,
+          overlay,
+        );
         latestHistoricalSnapshotBytes = latestHistoricalSnapshot.bytes;
       }
     } catch (error) {
@@ -190,7 +201,7 @@ function isTextLikePayloadPath(path: string): boolean {
     .test(path);
 }
 
-async function readPayloadFileWithOverlay(
+async function readBinaryPayloadFileWithOverlay(
   absolutePath: string,
   overlay?: ReadonlyMap<string, string>,
 ): Promise<{ text: string; bytes?: Uint8Array }> {

--- a/src/runtime/weave/memory_stats.ts
+++ b/src/runtime/weave/memory_stats.ts
@@ -1,5 +1,7 @@
 import type { PlannedFile } from "../../core/planned_file.ts";
+import type { WeaveableKnopCandidate } from "../../core/weave/candidates.ts";
 import type {
+  CandidateLiveSetRetainedMemoryStats,
   TextFileOverlay,
   TextFileOverlayRetainedMemoryStats,
 } from "./planning_context.ts";
@@ -40,6 +42,7 @@ export interface VersionExecutionRetainedMemoryStats {
     stores: number;
     invalidations: number;
   };
+  candidateLiveSet: CandidateLiveSetRetainedMemoryStats;
   planningLoopIterations: number;
   maxRssBytes: number;
 }
@@ -55,6 +58,11 @@ export interface RuntimeMemoryStatsReport
 }
 
 export interface RuntimeMemoryStats {
+  sampleCandidateLiveSet(
+    workspaceRoot: string,
+    candidates: readonly WeaveableKnopCandidate[],
+    overlay: TextFileOverlay,
+  ): void;
   samplePlanningLoopIteration(): void;
   captureVersionExecutionRetainedState(
     createdFiles: readonly PlannedFile[],
@@ -73,6 +81,28 @@ class EnabledRuntimeMemoryStats implements RuntimeMemoryStats {
 
   constructor(command: string) {
     this.#command = command;
+  }
+
+  sampleCandidateLiveSet(
+    workspaceRoot: string,
+    candidates: readonly WeaveableKnopCandidate[],
+    overlay: TextFileOverlay,
+  ): void {
+    const sampled = overlay.retainedCandidateLiveSetMemoryStats(
+      workspaceRoot,
+      candidates,
+    );
+    if (
+      sampled.approximateRetainedSourceTextBytes >
+        this.#retainedState.candidateLiveSet
+          .approximateRetainedSourceTextBytes ||
+      (sampled.approximateRetainedSourceTextBytes ===
+          this.#retainedState.candidateLiveSet
+            .approximateRetainedSourceTextBytes &&
+        sampled.entries > this.#retainedState.candidateLiveSet.entries)
+    ) {
+      this.#retainedState.candidateLiveSet = sampled;
+    }
   }
 
   samplePlanningLoopIteration(): void {
@@ -112,6 +142,7 @@ class EnabledRuntimeMemoryStats implements RuntimeMemoryStats {
       createdFiles: createdStats,
       updatedFileByPath: updatedStats,
       ...toReportedOverlayStats(overlayStats),
+      candidateLiveSet: this.#retainedState.candidateLiveSet,
       planningLoopIterations: this.#planningLoopIterations,
       maxRssBytes: this.#maxRssBytes,
     };
@@ -198,6 +229,12 @@ function emptyRetainedState(): VersionExecutionRetainedMemoryStats {
       approximateRetainedBytes: 0,
       stores: 0,
       invalidations: 0,
+    },
+    candidateLiveSet: {
+      entries: 0,
+      sourceTextReferences: 0,
+      distinctSourceTextIdentities: 0,
+      approximateRetainedSourceTextBytes: 0,
     },
     planningLoopIterations: 0,
     maxRssBytes: 0,

--- a/src/runtime/weave/planning_context.ts
+++ b/src/runtime/weave/planning_context.ts
@@ -11,6 +11,17 @@ interface CandidateCacheEntry {
   dependencyPaths: ReadonlySet<string>;
 }
 
+interface RetainedTextIdentity {
+  contents: string;
+}
+
+export interface CandidateLiveSetRetainedMemoryStats {
+  entries: number;
+  sourceTextReferences: number;
+  distinctSourceTextIdentities: number;
+  approximateRetainedSourceTextBytes: number;
+}
+
 export interface TextFileOverlayRetainedMemoryStats {
   stagedEntries: number;
   stagedBytes: number;
@@ -24,7 +35,8 @@ export interface TextFileOverlayRetainedMemoryStats {
 }
 
 export class TextFileOverlay extends Map<string, string> {
-  #readCache = new Map<string, string>();
+  #readCache = new Map<string, RetainedTextIdentity>();
+  #stagedTextIdentities = new Map<string, RetainedTextIdentity>();
   #candidateCache = new Map<string, CandidateCacheEntry>();
   #activeCandidateCapture: CandidateDependencyCapture | undefined;
   readCount = 0;
@@ -34,7 +46,10 @@ export class TextFileOverlay extends Map<string, string> {
   candidateCacheStoreCount = 0;
   candidateCacheInvalidationCount = 0;
 
-  async readTextFile(path: string): Promise<string> {
+  async readTextFile(
+    path: string,
+    contentsIfUncached?: string,
+  ): Promise<string> {
     this.#activeCandidateCapture?.dependencyPaths.add(path);
     const stagedContents = this.get(path);
     if (stagedContents !== undefined) {
@@ -42,14 +57,14 @@ export class TextFileOverlay extends Map<string, string> {
       return stagedContents;
     }
 
-    const cachedContents = this.#readCache.get(path);
-    if (cachedContents !== undefined) {
+    const cachedIdentity = this.#readCache.get(path);
+    if (cachedIdentity !== undefined) {
       this.cacheHitCount += 1;
-      return cachedContents;
+      return cachedIdentity.contents;
     }
 
-    const contents = await Deno.readTextFile(path);
-    this.#readCache.set(path, contents);
+    const contents = contentsIfUncached ?? await Deno.readTextFile(path);
+    this.#readCache.set(path, { contents });
     this.readCount += 1;
     return contents;
   }
@@ -93,6 +108,9 @@ export class TextFileOverlay extends Map<string, string> {
       )
     ) {
       this.set(absolutePath, file.contents);
+      this.#stagedTextIdentities.set(absolutePath, {
+        contents: file.contents,
+      });
     }
     this.#invalidateCandidates(stagedPaths);
   }
@@ -102,7 +120,9 @@ export class TextFileOverlay extends Map<string, string> {
       stagedEntries: this.size,
       stagedBytes: sumTextBytes(this.values()),
       readCacheEntries: this.#readCache.size,
-      readCacheBytes: sumTextBytes(this.#readCache.values()),
+      readCacheBytes: sumTextBytes(
+        [...this.#readCache.values()].map((entry) => entry.contents),
+      ),
       readCacheHits: this.cacheHitCount,
       candidateCacheEntries: this.#candidateCache.size,
       candidateCacheApproxRetainedBytes: [...this.#candidateCache.values()]
@@ -113,6 +133,42 @@ export class TextFileOverlay extends Map<string, string> {
         ),
       candidateCacheStores: this.candidateCacheStoreCount,
       candidateCacheInvalidations: this.candidateCacheInvalidationCount,
+    };
+  }
+
+  retainedCandidateLiveSetMemoryStats(
+    workspaceRoot: string,
+    candidates: readonly WeaveableKnopCandidate[],
+  ): CandidateLiveSetRetainedMemoryStats {
+    const retainedIdentities = new Set<RetainedTextIdentity>();
+    let sourceTextReferences = 0;
+    let distinctSourceTextIdentities = 0;
+    let approximateRetainedSourceTextBytes = 0;
+
+    for (const candidate of candidates) {
+      for (const sourceText of candidateSourceTexts(candidate)) {
+        sourceTextReferences += 1;
+        const absolutePath = join(workspaceRoot, sourceText.path);
+        const identity = this.#retainedTextIdentity(
+          absolutePath,
+          sourceText.contents,
+        );
+        if (identity !== undefined) {
+          if (retainedIdentities.has(identity)) {
+            continue;
+          }
+          retainedIdentities.add(identity);
+        }
+        distinctSourceTextIdentities += 1;
+        approximateRetainedSourceTextBytes += textBytes(sourceText.contents);
+      }
+    }
+
+    return {
+      entries: candidates.length,
+      sourceTextReferences,
+      distinctSourceTextIdentities,
+      approximateRetainedSourceTextBytes,
     };
   }
 
@@ -130,6 +186,18 @@ export class TextFileOverlay extends Map<string, string> {
       }
     }
   }
+
+  #retainedTextIdentity(
+    path: string,
+    contents: string,
+  ): RetainedTextIdentity | undefined {
+    const stagedIdentity = this.#stagedTextIdentities.get(path);
+    if (stagedIdentity?.contents === contents) {
+      return stagedIdentity;
+    }
+    const cachedIdentity = this.#readCache.get(path);
+    return cachedIdentity?.contents === contents ? cachedIdentity : undefined;
+  }
 }
 
 // A shared value instead of a TextEncoder-typed parameter: dnt's Node type
@@ -142,6 +210,50 @@ function sumTextBytes(values: Iterable<string>): number {
     total += RETAINED_BYTES_ENCODER.encode(value).byteLength;
   }
   return total;
+}
+
+function textBytes(value: string): number {
+  return RETAINED_BYTES_ENCODER.encode(value).byteLength;
+}
+
+function candidateSourceTexts(
+  candidate: WeaveableKnopCandidate,
+): readonly { path: string; contents: string }[] {
+  const sourceTexts: { path: string; contents: string }[] = [];
+  const payload = candidate.payloadArtifact;
+  if (payload !== undefined) {
+    sourceTexts.push({
+      path: payload.workingLocalRelativePath,
+      contents: payload.currentPayloadTurtle,
+    });
+    if (
+      payload.latestHistoricalSnapshotPath !== undefined &&
+      payload.latestHistoricalSnapshotTurtle !== undefined
+    ) {
+      sourceTexts.push({
+        path: payload.latestHistoricalSnapshotPath,
+        contents: payload.latestHistoricalSnapshotTurtle,
+      });
+    }
+  }
+
+  const referenceSource = candidate.referenceTargetSourcePayloadArtifact;
+  if (referenceSource !== undefined) {
+    sourceTexts.push({
+      path: referenceSource.workingLocalRelativePath,
+      contents: referenceSource.currentPayloadTurtle,
+    });
+    if (
+      referenceSource.latestHistoricalSnapshotPath !== undefined &&
+      referenceSource.latestHistoricalSnapshotTurtle !== undefined
+    ) {
+      sourceTexts.push({
+        path: referenceSource.latestHistoricalSnapshotPath,
+        contents: referenceSource.latestHistoricalSnapshotTurtle,
+      });
+    }
+  }
+  return sourceTexts;
 }
 
 function approximateCandidateRetainedBytes(
@@ -189,9 +301,10 @@ export function applyPlannedFilesToOverlay(
 export async function readTextFileWithOverlay(
   path: string,
   overlay?: ReadonlyMap<string, string>,
+  contentsIfUncached?: string,
 ): Promise<string> {
   if (overlay instanceof TextFileOverlay) {
-    return await overlay.readTextFile(path);
+    return await overlay.readTextFile(path, contentsIfUncached);
   }
 
   const stagedContents = overlay?.get(path);
@@ -199,7 +312,7 @@ export async function readTextFileWithOverlay(
     return stagedContents;
   }
 
-  return await Deno.readTextFile(path);
+  return contentsIfUncached ?? await Deno.readTextFile(path);
 }
 
 export async function readOptionalTextFileWithOverlay(

--- a/src/runtime/weave/version_execution.ts
+++ b/src/runtime/weave/version_execution.ts
@@ -353,6 +353,11 @@ export async function prepareVersionExecution(
         { sourceCapability },
       ),
   );
+  memoryStats?.sampleCandidateLiveSet(
+    workspaceRoot,
+    initialWeaveableKnops,
+    overlay,
+  );
   timing?.setField("initialWeaveableKnops", initialWeaveableKnops.length);
   const payloadBatchCandidates = shouldAttemptPayloadBatch
     ? await timeOptional(
@@ -524,6 +529,11 @@ export async function prepareVersionExecution(
           "prepare.loop.loadCandidates",
           { sourceCapability },
         ),
+    );
+    memoryStats?.sampleCandidateLiveSet(
+      workspaceRoot,
+      stagedWeaveableKnops,
+      overlay,
     );
 
     if (stagedWeaveableKnops.length === 0) {

--- a/tests/scripts/pending_heavy_mesh_test.ts
+++ b/tests/scripts/pending_heavy_mesh_test.ts
@@ -1,9 +1,21 @@
-import { assert, assertEquals, assertGreater } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertGreater,
+  assertStrictEquals,
+} from "@std/assert";
 import { fromFileUrl, join } from "@std/path";
 import {
   generatePendingHeavyMesh,
 } from "../../scripts/generate-pending-heavy-mesh.ts";
 import type { RuntimeMemoryStatsReport } from "../../src/runtime/weave/memory_stats.ts";
+import { loadOperationalLocalPathPolicy } from "../../src/runtime/operational/local_path_policy.ts";
+import { loadWeaveableKnopCandidates } from "../../src/runtime/weave/candidate_loader.ts";
+import { loadMeshState } from "../../src/runtime/weave/mesh_state.ts";
+import {
+  applyPlannedFilesToOverlay,
+  TextFileOverlay,
+} from "../../src/runtime/weave/planning_context.ts";
 import { createTestTmpDir } from "../support/test_tmp.ts";
 
 const repoRoot = fromFileUrl(new URL("../../", import.meta.url));
@@ -40,6 +52,16 @@ Deno.test("pending-heavy generator enters the instrumented recursive validation 
   );
   assertGreater(currentReport.candidateCache.stores, 0);
   assertGreater(currentReport.candidateCache.invalidations, 0);
+  assertEquals(currentReport.candidateLiveSet.entries, 3);
+  assertEquals(currentReport.candidateLiveSet.sourceTextReferences, 6);
+  assertEquals(
+    currentReport.candidateLiveSet.distinctSourceTextIdentities,
+    2,
+  );
+  assertGreater(
+    currentReport.candidateLiveSet.approximateRetainedSourceTextBytes,
+    0,
+  );
   assertGreater(currentReport.maxRssBytes, 0);
   assertGreater(currentReport.v8Heap.usedHeapSize, 0);
   assertEquals(currentReport.v8Heap.postGcUsedHeapSize, null);
@@ -60,6 +82,117 @@ Deno.test("pending-heavy generator enters the instrumented recursive validation 
   const disabled = await runValidate(currentOnlyRoot, "0");
   assert(disabled.output.success, disabled.stderr);
   assertEquals(disabled.stderr.includes("[memory-stats]"), false);
+});
+
+Deno.test("pending extracted candidates share cached source text and capture both payload dependencies", async () => {
+  const meshRoot = await createTestTmpDir(
+    "weave-pending-heavy-shared-source-",
+  );
+  await generatePendingHeavyMesh({
+    outputPath: meshRoot,
+    count: 2,
+    meshInventoryHistoryPolicy: "current-only",
+    termContentBytes: 256,
+  });
+
+  const meshState = await loadMeshState(meshRoot);
+  const localPathPolicy = await loadOperationalLocalPathPolicy(meshRoot);
+  const overlay = new TextFileOverlay();
+  const candidates = await loadWeaveableKnopCandidates(
+    meshRoot,
+    localPathPolicy,
+    meshState.meshBase,
+    meshState.currentMeshInventoryTurtle,
+    [],
+    new Map(),
+    overlay,
+  );
+  assertEquals(candidates.length, 2);
+
+  const firstSource = candidates[0]!.referenceTargetSourcePayloadArtifact!;
+  const secondSource = candidates[1]!.referenceTargetSourcePayloadArtifact!;
+  assertStrictEquals(
+    firstSource.currentPayloadTurtle,
+    secondSource.currentPayloadTurtle,
+  );
+  assertStrictEquals(
+    firstSource.latestHistoricalSnapshotTurtle,
+    secondSource.latestHistoricalSnapshotTurtle,
+  );
+
+  const sourceBytes = new TextEncoder().encode(firstSource.currentPayloadTurtle)
+    .byteLength;
+  assertEquals(
+    overlay.retainedCandidateLiveSetMemoryStats(meshRoot, candidates),
+    {
+      entries: 2,
+      sourceTextReferences: 4,
+      distinctSourceTextIdentities: 2,
+      approximateRetainedSourceTextBytes: sourceBytes * 2,
+    },
+  );
+
+  applyPlannedFilesToOverlay(meshRoot, overlay, [{
+    path: firstSource.workingLocalRelativePath,
+    contents: firstSource.currentPayloadTurtle,
+  }]);
+  assert(
+    overlay.candidateCacheInvalidationCount >= candidates.length,
+    "Expected the shared working payload path to invalidate every extracted candidate.",
+  );
+  const workingPayloadInvalidations = overlay.candidateCacheInvalidationCount;
+
+  await loadWeaveableKnopCandidates(
+    meshRoot,
+    localPathPolicy,
+    meshState.meshBase,
+    meshState.currentMeshInventoryTurtle,
+    [],
+    new Map(),
+    overlay,
+  );
+  applyPlannedFilesToOverlay(meshRoot, overlay, [{
+    path: firstSource.latestHistoricalSnapshotPath!,
+    contents: firstSource.latestHistoricalSnapshotTurtle!,
+  }]);
+  assert(
+    overlay.candidateCacheInvalidationCount - workingPayloadInvalidations >=
+      candidates.length,
+    "Expected the shared historical snapshot path to invalidate every extracted candidate.",
+  );
+});
+
+Deno.test("candidate live-set retained source bytes stay flat as pending count grows", async () => {
+  const twenty = await generateAndMeasureCandidateSourceRetention(20, 1024);
+  const sixty = await generateAndMeasureCandidateSourceRetention(60, 278);
+
+  assertEquals(twenty.report.candidateLiveSet.entries, 20);
+  assertEquals(sixty.report.candidateLiveSet.entries, 60);
+  assertEquals(twenty.report.candidateLiveSet.sourceTextReferences, 40);
+  assertEquals(sixty.report.candidateLiveSet.sourceTextReferences, 120);
+  assertEquals(
+    twenty.report.candidateLiveSet.distinctSourceTextIdentities,
+    2,
+  );
+  assertEquals(
+    sixty.report.candidateLiveSet.distinctSourceTextIdentities,
+    2,
+  );
+  assertEquals(
+    twenty.report.candidateLiveSet.approximateRetainedSourceTextBytes,
+    twenty.sourceBytes * 2,
+  );
+  assertEquals(
+    sixty.report.candidateLiveSet.approximateRetainedSourceTextBytes,
+    sixty.sourceBytes * 2,
+  );
+  assert(
+    Math.abs(
+      twenty.report.candidateLiveSet.approximateRetainedSourceTextBytes -
+        sixty.report.candidateLiveSet.approximateRetainedSourceTextBytes,
+    ) <= 128,
+    `Expected near-identical retained source bytes, got ${twenty.report.candidateLiveSet.approximateRetainedSourceTextBytes} and ${sixty.report.candidateLiveSet.approximateRetainedSourceTextBytes}.`,
+  );
 });
 
 Deno.test("pending-heavy generator materializes mesh-inventory history when requested", async () => {
@@ -148,6 +281,25 @@ async function runValidate(
     output,
     stderr: new TextDecoder().decode(output.stderr),
   };
+}
+
+async function generateAndMeasureCandidateSourceRetention(
+  count: number,
+  termContentBytes: number,
+): Promise<{ report: RuntimeMemoryStatsReport; sourceBytes: number }> {
+  const meshRoot = await createTestTmpDir(
+    `weave-pending-heavy-proportionality-${count}-`,
+  );
+  await generatePendingHeavyMesh({
+    outputPath: meshRoot,
+    count,
+    meshInventoryHistoryPolicy: "current-only",
+    termContentBytes,
+  });
+  const sourceBytes = (await Deno.stat(join(meshRoot, "source.ttl"))).size;
+  const validated = await runValidate(meshRoot, "1");
+  assert(validated.output.success, validated.stderr);
+  return { report: parseMemoryStats(validated.stderr), sourceBytes };
 }
 
 function parseMemoryStats(stderr: string): RuntimeMemoryStatsReport {


### PR DESCRIPTION
## Summary

The bounded-memory FIX slice ruled in archive note `wa.task.2026.2026-07-29_1220-whole-mesh-validate-bounded-memory` (amendment r2; R4 evidence gate passed before implementation). Payload and snapshot text reads now route through the command-scoped overlay read cache — with a seeded variant for the resolver's already-decoded text — so every pending extracted candidate holds a reference to ONE immutable string per distinct path instead of minting its own copies. Payload paths now register as candidate-cache dependencies (closing a known capture gap). Adds an identity-deduplicated candidate live-set counter to `WEAVE_MEMORY_STATS`.

- `df4587e` fix(validate): share candidate source payload text
- `61b9e53` test(validate): pin shared candidate source retention

## R4 evidence (gate before any fix code)

At N=200, growing source+snapshot text by 210 KB each left the read cache byte-identical (605 entries / 590,392 B) while peak RSS rose 292 → 665 MiB — the cache-bypass signature; both fresh-decode sites traced.

## Acceptance measurements (instrumented, --expose-gc, /usr/bin/time -v, current-only)

| Run | Before | After |
|---|---|---|
| N=500 @ 1 KB/term | 2.42 GiB peak RSS | **373 MiB** |
| N=1700 @ 1 KB/term (srd scale) | **V8 OOM at 14 s** (4.14 GiB) | **rc 0, 3m23s, 554 MiB** |
| N=1700 @ 0 B | 3m16s, 1.96 GiB | 3m26s, **485 MiB** (shared reads also cut re-read/decode churn) |

Live-set counter at N=1700: 3,400 source-text references → **2 distinct string identities** (~3.8 MB retained). Sharing immutable strings is behavior-neutral: findings identical, write paths byte-covered.

## Test evidence

Full `env -u NO_COLOR deno task ci`: **739 passed / 0 failed** (independently re-earned by the reviewing seat); `build:npm-lib` + off-tree Node smoke green locally (the dnt-shim lesson); focused shared-identity + proportionality suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)