### PR TITLE
release: prepare v0.6.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.1",
+  "version": "0.6.0",
   "tasks": {
     "dev:root": "deno run --allow-read --allow-write --allow-env --allow-net src/main.ts",
     "bump:version": "deno run --allow-read --allow-write scripts/bump-version.ts",

--- a/documentation/notes/release-notes.v0.6.0.md
+++ b/documentation/notes/release-notes.v0.6.0.md
@@ -1,18 +1,16 @@
 ---
 id: relnotesv060draft20260731
 title: 'release notes v0.6.0'
-desc: 'DRAFT — boarded 2026-07-31, unreleased; headline: programmatic validateMesh'
+desc: 'v0.6.0: programmatic validateMesh with structured findings; whole-mesh validate memory exhaustion fixed'
 updated: 1785527000000
 created: 1785527000000
 ---
-
-> **DRAFT — boarding stub (2026-07-31), not yet released.** Content lands from `lane/validate-mesh-api` and `lane/validate-memory-baseline` (see the landing plan in archive note `wa.task.2026.2026-07-29_1219-programmatic-validate-mesh-api`). Finalize wording, artifacts, and any late riders at release time.
 
 ## Summary
 
 `v0.6.0` delivers programmatic mesh validation: `validateMesh` in `@semantic-flow/weave-lib` (and the pinned-source root) returns structured findings with stable machine codes instead of formatted CLI text — the adoption-deciding ask from the Stagecraft consumer reviews ([[wd.consumer-feedback-0.5.1]] §8, re-raised in the 2026-07-29 follow-up). The consumption model for `weave` vs `weave-lib` is now documented contract, and the CLI and API consume one findings pipeline so they cannot drift.
 
-It also ships the validate memory-diagnosis tooling that turned the reported whole-mesh 4 GiB heap exhaustion from an anecdote into a reproducible, mechanistically attributed benchmark (the bounded-memory fix itself is tracked separately and may ride a later release).
+It also resolves the reported whole-mesh validate memory exhaustion end to end: the ~4 GiB heap ceiling hit on a ~6,900-file pending-heavy mesh was reproduced as a benchmark, attributed to per-candidate duplication of source payload text, and fixed — untargeted validation of a 1,700-pending-Knop mesh with realistic content goes from a 14-second out-of-memory crash to clean completion at ~550 MiB peak RSS. The diagnosis tooling (opt-in memory statistics and a pending-heavy mesh generator) ships with the release.
 
 ## Highlights
 
@@ -21,15 +19,17 @@ It also ships the validate memory-diagnosis tooling that turned the reported who
 - **New `read-failure` error code** (load stage, additive to the shared `WeaveApiErrorCode` union) for I/O-environment failures — `io-failure` remains write-stage-only.
 - **Typed capability limitation for floating repository sources:** `validateMesh` refuses meshes whose pending candidates need git-backed checkout identification with `unsupported-source`, replacing the misleading missing-working-payload degradation under Node. The capability-injected seam that would lift this is sketched as future work.
 - **Consumption-model ruling documented** ([[wu.api-reference]]): `weave-lib` sits alongside the CLI, never replaces it; the CLI is not becoming a wrapper; one version line, released together.
-- **Validate memory instrumentation** (opt-in `WEAVE_MEMORY_STATS=1`): retained-bytes accounting by role, loop iteration counts, peak RSS, and V8 heap statistics including post-GC discrimination under `--v8-flags=--expose-gc`; plus `scripts/generate-pending-heavy-mesh.ts`, a policy- and content-parameterized pending-heavy mesh generator. Together they reproduce the reported untargeted-validate heap exhaustion at srd scale and attribute it (per-candidate full-source duplication; parse churn).
+- **Whole-mesh validate memory exhaustion fixed.** Pending extracted-term candidates previously each minted their own copies of the full source payload text (twice per candidate); at ~1,700 pending Knops with realistic content that exhausted V8's default ~4 GiB heap in 14 seconds. Payload and snapshot text reads now share one immutable string per distinct path through the command-scoped read cache. Measured at the reported scale: N=1,700 @ 1 KB/term goes from out-of-memory to clean completion at ~554 MiB peak RSS; the same-cardinality no-content run drops from ~1.96 GiB to ~485 MiB peak with no wall-time regression.
+- **Validate memory instrumentation** (opt-in `WEAVE_MEMORY_STATS=1`): retained-bytes accounting by role (including an identity-deduplicated candidate live-set counter), loop iteration counts, peak RSS, and V8 heap statistics including post-GC discrimination under `--v8-flags=--expose-gc`; plus `scripts/generate-pending-heavy-mesh.ts`, a policy- and content-parameterized pending-heavy mesh generator — the tooling that reproduced, attributed, and now regression-guards the exhaustion.
 - The off-tree Node contract smoke gains settled and seeded-defect `validateMesh` legs; the npm-lib README/description now cover both APIs.
 
 ## Breaking Or Changed Behavior
 
 - **CLI validate: strict improvement, named per the behavioral-changelog rule.** Malformed inventory Turtle and config-resolution failures now surface as validate findings (exit 1 with a message, as other findings do) instead of escaping as uncaught crashes. Output text for previously-working cases and all exit-code semantics are unchanged (byte-covered by tests).
 - `WeaveApiErrorCode` gains `read-failure` (additive; `versionPayloads` never emits it). No existing code, stage, or field changes meaning.
+- Validate memory behavior improves substantially on pending-heavy meshes (see Highlights); findings, output text, and write-path behavior are byte-covered unchanged.
 - New public API surface only; CLI routing, binaries, packaging, `./src/mod.ts` imports, and `versionPayloads` behavior are unchanged.
 
-## Artifacts (to confirm at release)
+## Artifacts
 
-- npm: `@semantic-flow/weave`, four platform packages, `@semantic-flow/weave-lib`, all at `0.6.0`; tag `v0.6.0`; GitHub Release. Release mechanics per [[wd.release-runbook]] (dry-run + draft rehearsal first).
+- npm: `@semantic-flow/weave`, four platform packages, `@semantic-flow/weave-lib`, all at `0.6.0`; tag `v0.6.0`; GitHub Release.


### PR DESCRIPTION
Version bump to 0.6.0 and finalized release notes for the v0.6.0 release (programmatic validateMesh + whole-mesh validate memory fix; behavioral changes named per the changelog rule). `deno task ci` 739/739 on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the project to version 0.6.0.

* **Bug Fixes**
  * Improved whole-mesh validation memory usage, reducing memory exhaustion on large meshes.

* **Documentation**
  * Finalized the v0.6.0 release notes with updated behavior details, performance measurements, instrumentation, and release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->