### PR TITLE
fix(weave): allow nested extraction sources without root knops

### DIFF
--- a/src/core/weave/shape_assertions.ts
+++ b/src/core/weave/shape_assertions.ts
@@ -261,8 +261,6 @@ export function assertCurrentMeshInventoryShapeForFirstExtractedKnopWeave(
     "workingLocalRelativePath" | "repositorySourceFloatingLocator"
   >,
 ): void {
-  const rootDesignatorPath = toRootDesignatorPath(sourcePayloadDesignatorPath);
-  const rootKnopPath = toKnopPath(rootDesignatorPath);
   const sourceKnopPath = toKnopPath(sourcePayloadDesignatorPath);
   const knopPath = toKnopPath(designatorPath);
   const designatorPagePath = toDesignatorResourcePagePath(designatorPath);
@@ -301,17 +299,6 @@ export function assertCurrentMeshInventoryShapeForFirstExtractedKnopWeave(
       SFLO_HAS_RESOURCE_PAGE_IRI,
       sourcePayloadPagePath,
     ],
-    [rootKnopPath, RDF_TYPE_IRI, SFLO_KNOP_IRI],
-    [
-      rootKnopPath,
-      SFLO_HAS_WORKING_KNOP_INVENTORY_FILE_IRI,
-      `${rootKnopPath}/_inventory/inventory.ttl`,
-    ],
-    ...(rootKnopPath === knopPath ? [] : [[
-      rootKnopPath,
-      SFLO_HAS_RESOURCE_PAGE_IRI,
-      `${rootKnopPath}/index.html`,
-    ]] as const),
     [sourceKnopPath, RDF_TYPE_IRI, SFLO_KNOP_IRI],
     [
       sourceKnopPath,
@@ -997,13 +984,6 @@ export function assertHasLiteralFacts(
       throw new WeaveInputError(errorMessage);
     }
   }
-}
-
-function toRootDesignatorPath(designatorPath: string): string {
-  const firstSlash = designatorPath.indexOf("/");
-  return firstSlash === -1
-    ? designatorPath
-    : designatorPath.slice(0, firstSlash);
 }
 
 function toHistoryPathFromStatePath(statePath: string): string {

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -3362,6 +3362,81 @@ Deno.test("planWeave renders the extracted bob woven slice", async () => {
   assertStringIncludes(bobPage?.contents ?? "", "<h1>bob</h1>");
 });
 
+Deno.test("planWeave renders an extracted term from a nested source without a root Knop", async () => {
+  const input = await createExtractedBobWeaveInput();
+  input.currentMeshInventoryTurtle = input.currentMeshInventoryTurtle
+    .replace("  sflo:hasKnop <alice/_knop> ;\n", "")
+    .replace(
+      `<alice/_knop> a sflo:Knop ;
+  sflo:hasWorkingKnopInventoryFile <alice/_knop/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <alice/_knop/index.html> .
+
+`,
+      "",
+    )
+    .replace(
+      `<alice/_knop/_inventory/inventory.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+
+`,
+      "",
+    )
+    .replace(
+      `<alice/_knop/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+`,
+      "",
+    );
+  input.supportHistoryPolicies = {
+    meshInventory: "currentOnly",
+    knopMetadata: "currentOnly",
+    knopInventory: "currentOnly",
+  };
+  assertFalse(input.currentMeshInventoryTurtle.includes("<alice/_knop"));
+
+  const plan = planWeave(input);
+  const meshInventory =
+    plan.updatedFiles.find((file) =>
+      file.path === "_mesh/_inventory/inventory.ttl"
+    )?.contents ?? "";
+
+  assertEquals(plan.wovenDesignatorPaths, ["bob"]);
+  assertStringIncludes(
+    meshInventory,
+    `<alice/data> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <alice-data.ttl> ;
+  sflo:hasResourcePage <alice/data/index.html> .`,
+  );
+  assertStringIncludes(
+    meshInventory,
+    `<alice/data/_knop> a sflo:Knop ;
+  sflo:hasWorkingKnopInventoryFile <alice/data/_knop/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <alice/data/_knop/index.html> .`,
+  );
+  assertStringIncludes(
+    meshInventory,
+    "<bob> sflo:hasResourcePage <bob/index.html> .",
+  );
+  assertStringIncludes(
+    meshInventory,
+    "<bob/_knop> sflo:hasResourcePage <bob/_knop/index.html> .",
+  );
+  assert(
+    plan.createdFiles.some((file) => file.path === "bob/index.html"),
+  );
+  assert(
+    plan.createdPages.some((page) => page.path === "bob/_knop/index.html"),
+  );
+  assertFalse(
+    [...plan.createdFiles, ...plan.updatedFiles].some((file) =>
+      file.path.startsWith("alice/_knop") ||
+      file.contents.includes("<alice/_knop")
+    ),
+  );
+  assertFalse(
+    plan.createdPages.some((page) => page.path.startsWith("alice/_knop")),
+  );
+});
+
 Deno.test("planWeave accepts extracted terms from floating repository source payloads", async () => {
   const input = await createExtractedBobWeaveInput();
   const repositorySourceFloatingLocator = {


### PR DESCRIPTION
Bite 1 of the extract→weave scale work in `wa.task.2026.2026-07-21_1603-extractor-defect-pair` (Kim brief in that note; carved and fired from planning-loop wakes 2–3).

## What

`assertCurrentMeshInventoryShapeForFirstExtractedKnopWeave` demanded a Knop, working inventory locator, and ResourcePage for the source payload's *derived first path segment* — so a targeted `firstExtractedKnopWeave` from a nested source like `alice/data` refused whenever the namespace-like `alice` had no `alice/_knop`. The corpus diagnosis isolated this as the immediate blocker at Stagecraft's ~1,700-term nested-source scale (adding only fictional root-Knop facts made validation pass). A grouping path is not automatically a managed Semantic Flow identifier: the derived-root requirements are removed, the actual source payload/Knop and target-Knop assertions are unchanged, and the dead `toRootDesignatorPath` helper is deleted.

## Evidence

- Fail-on-old recorded: `WeaveInputError: The current local weave slice only supports the settled extracted-knop pre-weave mesh inventory shape for bob.`
- New regression (current-only support policies, matching the SRD failure arm): bob weaves, identifier and Knop page claims render, nested source facts survive byte-for-byte, and no `alice/_knop` facts, files, or pages are synthesized.
- Full `deno task ci` green; `deno task build:npm-lib` green (dnt).

## Not in this bite (stays boarded on the task note)

Versioned nested-source behavior, untargeted/multi-target agreement, MeshInventory history-index rendering (the fixed `_s0001`–`_s0004` list), heavy-mesh generator nested-source mode, the ~1,700-term regression workload, and any claim of full extract→weave→generate viability — the Stagecraft workaround does not retire yet.

Implemented by Codex (`codex exec`) as Kim under the standing loop-wake grant; reviewed, validated, and landed by the planning seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHrFYeUefDr227gLuWWuq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extraction validation for nested source terms by relying on the source Knop path.
  - Nested terms can now be extracted and woven successfully when no root Knop is present.
  - Prevented unnecessary recreation of missing root Knop metadata and resource artifacts.

- **Tests**
  - Added regression coverage for nested-term extraction and weaving without a root Knop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->