### PR TITLE
test(weave): generate nested-source pending-heavy meshes

### DIFF
--- a/scripts/generate-pending-heavy-mesh.ts
+++ b/scripts/generate-pending-heavy-mesh.ts
@@ -11,6 +11,7 @@ export interface GeneratePendingHeavyMeshOptions {
   count: number;
   meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
   termContentBytes?: number;
+  sourceDesignatorPath?: string;
 }
 
 export interface GeneratePendingHeavyMeshResult {
@@ -22,7 +23,7 @@ export interface GeneratePendingHeavyMeshResult {
   extractedDesignatorPaths: readonly string[];
 }
 
-const SOURCE_DESIGNATOR_PATH = "source";
+const DEFAULT_SOURCE_DESIGNATOR_PATH = "source";
 const SOURCE_WORKING_FILE_PATH = "source.ttl";
 
 export async function generatePendingHeavyMesh(
@@ -31,6 +32,8 @@ export async function generatePendingHeavyMesh(
   assertPositiveInteger(options.count, "count");
   const termContentBytes = options.termContentBytes ?? 0;
   assertNonNegativeInteger(termContentBytes, "termContentBytes");
+  const sourceDesignatorPath = options.sourceDesignatorPath ??
+    DEFAULT_SOURCE_DESIGNATOR_PATH;
   const meshRoot = resolve(options.outputPath);
   await ensureEmptyOutputDirectory(meshRoot);
 
@@ -56,20 +59,20 @@ export async function generatePendingHeavyMesh(
   await executeIntegrate({
     meshRoot,
     request: {
-      designatorPath: SOURCE_DESIGNATOR_PATH,
+      designatorPath: sourceDesignatorPath,
       source: SOURCE_WORKING_FILE_PATH,
     },
   });
   await executeWeave({
     meshRoot,
     request: {
-      targets: [{ designatorPath: SOURCE_DESIGNATOR_PATH }],
+      targets: [{ designatorPath: sourceDesignatorPath }],
     },
   });
 
   const extraction = await executeExtractAllTerms({
     meshRoot,
-    request: { sourceDesignatorPath: SOURCE_DESIGNATOR_PATH },
+    request: { sourceDesignatorPath },
   });
   if (extraction.extractedDesignatorPaths.length !== options.count) {
     throw new Error(
@@ -82,7 +85,7 @@ export async function generatePendingHeavyMesh(
     count: options.count,
     meshInventoryHistoryPolicy: options.meshInventoryHistoryPolicy,
     termContentBytes,
-    sourceDesignatorPath: SOURCE_DESIGNATOR_PATH,
+    sourceDesignatorPath,
     extractedDesignatorPaths: extraction.extractedDesignatorPaths,
   };
 }
@@ -175,6 +178,7 @@ interface ParsedArgs {
   count: number;
   meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy;
   termContentBytes: number;
+  sourceDesignatorPath: string;
 }
 
 function parseArgs(args: readonly string[]): ParsedArgs {
@@ -182,6 +186,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
   let count: number | undefined;
   let meshInventoryHistoryPolicy: MeshInventoryHistoryPolicy = "current-only";
   let termContentBytes = 0;
+  let sourceDesignatorPath = DEFAULT_SOURCE_DESIGNATOR_PATH;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
@@ -211,6 +216,11 @@ function parseArgs(args: readonly string[]): ParsedArgs {
       index += 1;
       continue;
     }
+    if (arg === "--source-designator-path" && value !== undefined) {
+      sourceDesignatorPath = value;
+      index += 1;
+      continue;
+    }
     throw new Error(`Unknown or incomplete argument: ${arg}`);
   }
 
@@ -227,6 +237,7 @@ function parseArgs(args: readonly string[]): ParsedArgs {
     count,
     meshInventoryHistoryPolicy,
     termContentBytes,
+    sourceDesignatorPath,
   };
 }
 
@@ -242,7 +253,7 @@ if (import.meta.main) {
           dirname(import.meta.filename!),
           "generate-pending-heavy-mesh.ts",
         )
-      } --output <empty-dir> --count <N> --mesh-inventory-history <current-only|versioned> [--term-content-bytes <n>]`,
+      } --output <empty-dir> --count <N> --mesh-inventory-history <current-only|versioned> [--term-content-bytes <n>] [--source-designator-path <path>]`,
     );
     Deno.exit(1);
   }

--- a/tests/scripts/pending_heavy_mesh_test.ts
+++ b/tests/scripts/pending_heavy_mesh_test.ts
@@ -2,6 +2,7 @@ import {
   assert,
   assertEquals,
   assertGreater,
+  assertRejects,
   assertStrictEquals,
 } from "@std/assert";
 import { fromFileUrl, join } from "@std/path";
@@ -82,6 +83,69 @@ Deno.test("pending-heavy generator enters the instrumented recursive validation 
   const disabled = await runValidate(currentOnlyRoot, "0");
   assert(disabled.output.success, disabled.stderr);
   assertEquals(disabled.stderr.includes("[memory-stats]"), false);
+});
+
+Deno.test("pending-heavy generator preserves a nested source without an ancestor Knop", async () => {
+  const meshRoot = await createTestTmpDir(
+    "weave-pending-heavy-nested-source-",
+  );
+  const options = {
+    outputPath: meshRoot,
+    count: 3,
+    meshInventoryHistoryPolicy: "current-only" as const,
+    sourceDesignatorPath: "catalog/source",
+  };
+  const generated = await generatePendingHeavyMesh(options);
+
+  assertEquals(generated.sourceDesignatorPath, "catalog/source");
+  assertEquals(generated.extractedDesignatorPaths, [
+    "term-000001",
+    "term-000002",
+    "term-000003",
+  ]);
+  assert(
+    (await Deno.stat(
+      join(
+        meshRoot,
+        "catalog/source/_knop/_inventory/inventory.ttl",
+      ),
+    )).isFile,
+  );
+  await assertRejects(
+    () => Deno.stat(join(meshRoot, "catalog/_knop")),
+    Deno.errors.NotFound,
+  );
+
+  const meshInventoryTurtle = await Deno.readTextFile(
+    join(meshRoot, "_mesh/_inventory/inventory.ttl"),
+  );
+  assertEquals(
+    meshInventoryTurtle.includes("catalog/_knop"),
+    false,
+    meshInventoryTurtle,
+  );
+
+  const meshState = await loadMeshState(meshRoot);
+  const localPathPolicy = await loadOperationalLocalPathPolicy(meshRoot);
+  const candidates = await loadWeaveableKnopCandidates(
+    meshRoot,
+    localPathPolicy,
+    meshState.meshBase,
+    meshState.currentMeshInventoryTurtle,
+    [],
+    new Map(),
+    new TextFileOverlay(),
+  );
+  assertEquals(
+    candidates.map((candidate) => candidate.designatorPath),
+    generated.extractedDesignatorPaths,
+  );
+  for (const candidate of candidates) {
+    assertEquals(
+      candidate.referenceTargetSourcePayloadArtifact?.designatorPath,
+      "catalog/source",
+    );
+  }
 });
 
 Deno.test("pending extracted candidates share cached source text and capture both payload dependencies", async () => {


### PR DESCRIPTION
Bite 2 of the extract→weave scale work in `wa.task.2026.2026-07-21_1603-extractor-defect-pair` (Kim brief in that note; carved and fired from planning-loop wakes 4–6). Companion to #31, deliberately independent of it.

## What

`generatePendingHeavyMesh` gains an optional `sourceDesignatorPath` (default `"source"`, existing behavior preserved), exposed as `--source-designator-path <path>`. In nested mode the generator creates and weaves `catalog/source` as the actual payload with `catalog/source/_knop`, leaves `catalog` an unmanaged grouping path (no `catalog/_knop`), and extracts N pending root-level terms bound to `catalog/source` through their extraction sources — the faithful reproduction of the diagnosed `srd-5-2-1/spells`-without-`srd-5-2-1/_knop` corpus topology that the flat generator could not express.

## Evidence

- Fail-on-old recorded: the focused regression failed against the unmodified generator (actual `source` vs expected `catalog/source`).
- Regression asserts: nested source Knop inventory exists; `catalog/_knop` exists neither as files nor as MeshInventory facts; exactly N terms extracted and loadable as pending candidates; every candidate's `referenceTargetSourcePayloadArtifact.designatorPath` is `catalog/source`. Deliberately no pending-term planning (that would couple this bite to #31).
- Kim's report: nested integrate/weave needed no ancestor Knop; candidate loading resolved the nested source with zero production changes.
- Full `deno task ci` green.

## Not in this bite

Planner/batching/memory changes, targeted/untargeted agreement, history-index correction, the ~1,700-term run, any viability claim.

Implemented by Codex (`codex exec`) as Kim under the standing loop-wake grant; reviewed, validated, and landed by the planning seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHrFYeUefDr227gLuWWuq1