### PR TITLE
feat(weave): batch untargeted multi-pending first-payload weave

### DIFF
--- a/src/core/weave/weave.ts
+++ b/src/core/weave/weave.ts
@@ -227,7 +227,19 @@ export function planWeave(input: PlanWeaveInput): WeavePlan {
     throw new WeaveInputError("No weave candidates were found.");
   }
   if (weaveableKnops.length !== 1) {
-    if (requestedTargets.length > 1 && !overwriteExistingState) {
+    const isUntargetedFirstPayloadBatch = requestedTargets.length === 0 &&
+      !overwriteExistingState &&
+      weaveableKnops.every((selection) =>
+        classifyWeaveSlice(
+          meshBase,
+          selection.candidate,
+          selection.target,
+        ) === "firstPayloadWeave"
+      );
+    if (
+      !overwriteExistingState &&
+      (requestedTargets.length > 1 || isUntargetedFirstPayloadBatch)
+    ) {
       const plan = planExplicitPayloadBatchWeave(
         meshBase,
         input.currentMeshInventoryTurtle,

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -963,7 +963,9 @@ Deno.test("planWeave renders the first alice bio payload weave slice", () => {
   );
 });
 
-Deno.test("planWeave batches explicit first payload targets with one merged MeshInventory progression", () => {
+function firstPayloadBatchInput(
+  request: PlanWeaveInput["request"],
+): PlanWeaveInput {
   const meshBase = "https://semantic-flow.github.io/mesh-alice-bio/";
   const currentMeshInventoryTurtle = `@base <${meshBase}> .
 @prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .
@@ -1049,13 +1051,8 @@ Deno.test("planWeave batches explicit first payload targets with one merged Mesh
   sflo:hasWorkingLocatedFile <${workingLocalRelativePath}> .
 `;
 
-  const plan = planWeave({
-    request: {
-      targets: [
-        { designatorPath: "bob/data" },
-        { designatorPath: "alice/data" },
-      ],
-    },
+  return {
+    request,
     meshBase,
     currentMeshInventoryTurtle,
     currentMeshMetadataTurtle,
@@ -1093,7 +1090,21 @@ Deno.test("planWeave batches explicit first payload targets with one merged Mesh
         },
       },
     ],
-  });
+    supportHistoryPolicies: {
+      meshInventory: "versioned",
+      knopMetadata: "versioned",
+      knopInventory: "versioned",
+    },
+  };
+}
+
+Deno.test("planWeave batches explicit first payload targets with one merged MeshInventory progression", () => {
+  const plan = planWeave(firstPayloadBatchInput({
+    targets: [
+      { designatorPath: "bob/data" },
+      { designatorPath: "alice/data" },
+    ],
+  }));
 
   assertEquals(plan.wovenDesignatorPaths, ["alice/data", "bob/data"]);
   assertEquals(
@@ -1139,6 +1150,70 @@ Deno.test("planWeave batches explicit first payload targets with one merged Mesh
     meshMetadata,
     'sflo:nextStateOrdinal "4"^^xsd:nonNegativeInteger .',
   );
+});
+
+Deno.test("planWeave batches untargeted first payload candidates in canonical order", () => {
+  const plan = planWeave(firstPayloadBatchInput({}));
+
+  assertEquals(plan.wovenDesignatorPaths, ["alice/data", "bob/data"]);
+  assertEquals(
+    plan.createdFiles.filter((file) =>
+      file.path.startsWith("_mesh/_inventory/_history001/_s0003/")
+    ).map((file) => file.path),
+    ["_mesh/_inventory/_history001/_s0003/ttl/inventory.ttl"],
+  );
+  assertEquals(
+    plan.updatedFiles.filter((file) =>
+      file.path === "_mesh/_inventory/inventory.ttl"
+    ).length,
+    1,
+  );
+  const createdPaths = plan.createdFiles.map((file) => file.path);
+  for (const designatorPath of ["alice/data", "bob/data"]) {
+    assert(createdPaths.includes(
+      `${designatorPath}/_history001/_s0001/ttl/${
+        designatorPath === "alice/data" ? "alice-data.ttl" : "bob-data.ttl"
+      }`,
+    ));
+    assert(createdPaths.includes(
+      `${designatorPath}/_knop/_meta/_history001/_s0001/ttl/meta.ttl`,
+    ));
+    assert(createdPaths.includes(
+      `${designatorPath}/_knop/_inventory/_history001/_s0001/ttl/inventory.ttl`,
+    ));
+  }
+  const meshInventory =
+    plan.updatedFiles.find((file) =>
+      file.path === "_mesh/_inventory/inventory.ttl"
+    )?.contents ?? "";
+  assertStringIncludes(
+    meshInventory,
+    "sflo:hasKnop <alice/data/_knop> ;\n  sflo:hasKnop <bob/data/_knop> ;",
+  );
+  for (const designatorPath of ["alice/data", "bob/data"]) {
+    assertStringIncludes(
+      meshInventory,
+      `<${designatorPath}> a sflo:PayloadArtifact, sflo:DigitalArtifact, sflo:RdfDocument ;`,
+    );
+    const knopInventory = plan.updatedFiles.find((file) =>
+      file.path === `${designatorPath}/_knop/_inventory/inventory.ttl`
+    )?.contents ?? "";
+    assertStringIncludes(
+      knopInventory,
+      `sflo:currentArtifactHistory <${designatorPath}/_history001> ;`,
+    );
+  }
+});
+
+Deno.test("planWeave keeps an exact target narrow beside untargeted first payload candidates", () => {
+  const plan = planWeave(firstPayloadBatchInput({
+    targets: [{ designatorPath: "alice/data" }],
+  }));
+
+  assertEquals(plan.wovenDesignatorPaths, ["alice/data"]);
+  for (const file of [...plan.createdFiles, ...plan.updatedFiles]) {
+    assertFalse(file.path === "bob/data" || file.path.startsWith("bob/data/"));
+  }
 });
 
 Deno.test("planWeave preserves floating repository payload source locators", () => {

--- a/src/runtime/weave/version_execution.ts
+++ b/src/runtime/weave/version_execution.ts
@@ -410,16 +410,25 @@ export async function prepareVersionExecution(
   });
   const meshEffectiveConfig = await effectiveConfigProvider
     .configForMeshScope();
+  const untargetedFirstPayloadBatch = targets.length === 0 &&
+    isUntargetedFirstPayloadBatch(
+      meshState.meshBase,
+      initialWeaveableKnops,
+    );
+  const batchCandidates = untargetedFirstPayloadBatch
+    ? initialWeaveableKnops
+    : payloadBatchCandidates;
 
   if (
-    payloadBatchCandidates.length > 0 &&
-    isExplicitPayloadBatch(
-      meshState.meshBase,
-      payloadBatchCandidates,
-      targetByDesignatorPath,
-    )
+    batchCandidates.length > 0 &&
+    (untargetedFirstPayloadBatch ||
+      isExplicitPayloadBatch(
+        meshState.meshBase,
+        batchCandidates,
+        targetByDesignatorPath,
+      ))
   ) {
-    assertRequestedTargetsAreWeaveable(targets, payloadBatchCandidates);
+    assertRequestedTargetsAreWeaveable(targets, batchCandidates);
     const batchPlan = await timeOptional(
       timing,
       "prepare.planPayloadBatch",
@@ -427,7 +436,7 @@ export async function prepareVersionExecution(
         try {
           return await planExplicitPayloadBatchVersion(
             meshState,
-            payloadBatchCandidates,
+            batchCandidates,
             targetByDesignatorPath,
             meshEffectiveConfig,
             effectiveConfigProvider,
@@ -899,6 +908,20 @@ function isExplicitPayloadBatch(
         targetByDesignatorPath.get(candidate.designatorPath) !== undefined &&
         candidate.payloadArtifact?.currentArtifactHistoryPath !== undefined);
   });
+}
+
+function isUntargetedFirstPayloadBatch(
+  meshBase: string,
+  candidates: readonly WeaveableKnopCandidate[],
+): boolean {
+  return candidates.length > 1 &&
+    candidates.every((candidate) =>
+      detectPendingWeaveSlice(
+        meshBase,
+        candidate.designatorPath,
+        candidate.currentKnopInventoryTurtle,
+      ) === "firstPayloadWeave"
+    );
 }
 
 async function planExplicitPayloadBatchVersion(

--- a/tests/integration/weave_test.ts
+++ b/tests/integration/weave_test.ts
@@ -192,6 +192,86 @@ Deno.test("executeWeave materializes current support ResourcePages for a docs-ro
   );
 });
 
+Deno.test("executeWeave batches a docs-rooted multi-pending first payload weave", async () => {
+  const workspaceRoot = await createTestTmpDir(
+    "weave-weave-sidecar-multi-pending-first-payload-",
+  );
+  const meshRoot = join(workspaceRoot, "docs");
+  await executeMeshCreate({
+    workspaceRoot,
+    meshRoot: "docs",
+    request: {
+      meshBase: sidecarFantasyRulesBase,
+    },
+  });
+  await executeWeave({
+    meshRoot,
+    historyTrackingPolicyOverride: "versioned",
+  });
+
+  await Deno.writeTextFile(
+    join(meshRoot, "ontology.ttl"),
+    `@base <${sidecarFantasyRulesBase}> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+<ontology> a owl:Ontology .
+`,
+  );
+  await Deno.writeTextFile(
+    join(meshRoot, "shacl.ttl"),
+    `@base <${sidecarFantasyRulesBase}> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+<shacl> a sh:NodeShape .
+`,
+  );
+  for (const designatorPath of ["ontology", "shacl"]) {
+    await executeIntegrate({
+      meshRoot,
+      request: {
+        designatorPath,
+        source: `${designatorPath}.ttl`,
+      },
+    });
+  }
+
+  const result = await executeWeave({
+    meshRoot,
+    historyTrackingPolicyOverride: "versioned",
+  });
+
+  assertEquals(result.wovenDesignatorPaths, ["ontology", "shacl"]);
+  assertEquals(
+    result.createdPaths.filter((path) =>
+      /^docs\/_mesh\/_inventory\/_history001\/_s\d+\/ttl\/inventory\.ttl$/.test(
+        path,
+      )
+    ),
+    ["docs/_mesh/_inventory/_history001/_s0002/ttl/inventory.ttl"],
+  );
+  for (const designatorPath of ["ontology", "shacl"]) {
+    assert(result.createdPaths.includes(
+      `docs/${designatorPath}/_history001/_s0001/ttl/${designatorPath}.ttl`,
+    ));
+    assert(result.createdPaths.includes(`docs/${designatorPath}/index.html`));
+    assert(result.createdPaths.includes(
+      `docs/${designatorPath}/_history001/index.html`,
+    ));
+    await Deno.stat(join(meshRoot, designatorPath, "index.html"));
+  }
+  const meshMetadata = await Deno.readTextFile(
+    join(meshRoot, "_mesh/_meta/meta.ttl"),
+  );
+  assertStringIncludes(
+    meshMetadata,
+    "sflo:latestHistoricalState <_mesh/_inventory/_history001/_s0002> ;",
+  );
+  assertStringIncludes(
+    meshMetadata,
+    'sflo:nextStateOrdinal "3"^^xsd:nonNegativeInteger',
+  );
+});
+
 Deno.test("executeWeave refreshes ancestor ResourcePages when a child designator is woven", async () => {
   const workspaceRoot = await createTestTmpDir(
     "weave-weave-refresh-ancestor-pages-",


### PR DESCRIPTION
First-payload bite 1 of `wa.task.2026.2026-07-03_1332-stagecraft-weave-planner-generalization` (Kim brief in that note; carved and fired from planning-loop wakes 6–8). Addresses the first remaining P1 blocker: multi-pending first-payload weave in one transaction — where "transaction" means one validated `VersionPlan` and one shared MeshInventory progression, not filesystem atomicity (application-owned, per the recorded decision).

## What

Untargeted `weave` over two-plus pending candidates that ALL classify as `firstPayloadWeave` now routes through the existing coherent payload-batch planner instead of refusing with the single-candidate cardinality error. One deterministic plan, canonical designator ordering, both payload histories plus configured Knop support histories, one working MeshInventory update, and — under versioned MeshInventory policy — exactly one new HistoricalState per command. Single-target, explicit multi-target, exact-target narrowing, and untargeted mixed/recursive/later-payload sets are all preserved on their existing paths.

## Evidence

- Fail-on-old, all three tests: the untargeted core batch failed with `supports exactly one weave candidate; found 2`; the integration test failed because the old sequential loop created `_s0002` AND `_s0003` where one state was owed; the exact-target regression passed on old code (confirming preserved narrowing).
- Full core planner suite 71 green; recursive mixed-slice, single later-payload, and explicit later-payload batch regressions green; full `deno task ci` green.
- Kim's report: no renderer or progression-resolver changes needed; differing scoped policies remain fail-closed; no checkpoint double-hash guarantee added (separate contract decision).

## Not in this bite

Current-mode extracted-term preservation (sequenced after #31), condition-specific diagnostics, later-payload/recursive/mixed batching, locking/rollback.

Implemented by Codex (`codex exec`) as Kim under the standing loop-wake grant; reviewed, validated, and landed by the planning seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHrFYeUefDr227gLuWWuq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing multiple initial payloads together in untargeted weave requests.
  * Multiple payloads can now be integrated in a single operation, with corresponding files and resource pages created.
  * Weaving advances metadata correctly after processing batched payloads.

* **Bug Fixes**
  * Improved target-specific processing so unrelated payloads remain isolated during targeted requests.

* **Tests**
  * Added coverage for multi-payload and targeted weaving scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->