### PR TITLE
fix(weave): append-only current-only ReferenceCatalog inventory weave

### DIFF
--- a/src/core/weave/knop_inventory_renderers.ts
+++ b/src/core/weave/knop_inventory_renderers.ts
@@ -1,10 +1,12 @@
 import { toKnopPath, toReferenceCatalogPath } from "../designator_segments.ts";
 import {
+  RDF_NAMESPACE,
   SFLO_NAMESPACE,
   SFLO_TURTLE_PREFIX_DECLARATION,
 } from "../rdf/namespaces.ts";
 import { toArtifactManifestationPath } from "./artifact_manifestation_paths.ts";
 import { WeaveInputError } from "./errors.ts";
+import { planInventoryAppend } from "./inventory_append_planner.ts";
 import type {
   MeshInventoryProgression,
   PageDefinitionWeaveProgression,
@@ -302,51 +304,80 @@ ${currentWorkingFileDeclaration}
 }
 
 export function renderCurrentOnlyReferenceCatalogWovenKnopInventoryTurtle(
-  _meshBase: string,
+  meshBase: string,
   currentKnopInventoryTurtle: string,
   designatorPath: string,
   workingLocalRelativePath: string,
 ): string {
   const referenceCatalogPath = toReferenceCatalogPath(designatorPath);
   const referenceCatalogPagePath = `${referenceCatalogPath}/index.html`;
-  const blocks = splitTurtleBlocks(currentKnopInventoryTurtle);
-  const currentReferenceCatalogBlockIndex = findSubjectBlockIndex(
-    blocks,
-    referenceCatalogPath,
-  );
-  if (currentReferenceCatalogBlockIndex === -1) {
+  const requestedSettledFactsTurtle = `@base <${meshBase}> .
+${SFLO_TURTLE_PREFIX_DECLARATION}
+
+<${referenceCatalogPath}> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <${workingLocalRelativePath}> ;
+  sflo:hasResourcePage <${referenceCatalogPagePath}> .
+
+<${referenceCatalogPagePath}> a sflo:ResourcePage, sflo:LocatedFile .
+`;
+  const plan = planInventoryAppend({
+    baseIri: meshBase,
+    currentInventoryTurtle: currentKnopInventoryTurtle,
+    requestedSettledFactsTurtle,
+    singleValuedSettledPredicates: [
+      `${SFLO_NAMESPACE}hasWorkingLocatedFile`,
+    ],
+    currentInventoryLabel: `current KnopInventory for ${designatorPath}`,
+    requestedFactsLabel:
+      `current-only ReferenceCatalog weave facts for ${designatorPath}`,
+  });
+
+  if (plan.kind === "conflict") {
     throw new WeaveInputError(
-      `Current KnopInventory did not contain ReferenceCatalog block <${referenceCatalogPath}>.`,
+      `Could not append current-only ReferenceCatalog inventory facts for ${designatorPath}: ${
+        plan.conflicts.map((conflict) => conflict.message).join(" ")
+      }`,
     );
   }
 
-  const currentReferenceCatalogBlock =
-    blocks[currentReferenceCatalogBlockIndex]!;
-  if (
-    !currentReferenceCatalogBlock.includes(`<${workingLocalRelativePath}>`) &&
-    !currentReferenceCatalogBlock.includes(`"${workingLocalRelativePath}"`)
+  if (plan.kind === "unchanged") {
+    return plan.outputTurtle;
+  }
+
+  let compactAppendTurtle = plan.appendTurtle
+    .replaceAll(`<${RDF_NAMESPACE}type>`, "a")
+    .replaceAll(
+      `<${SFLO_NAMESPACE}ReferenceCatalog>`,
+      "sflo:ReferenceCatalog",
+    )
+    .replaceAll(`<${SFLO_NAMESPACE}DigitalArtifact>`, "sflo:DigitalArtifact")
+    .replaceAll(`<${SFLO_NAMESPACE}RdfDocument>`, "sflo:RdfDocument")
+    .replaceAll(
+      `<${SFLO_NAMESPACE}hasWorkingLocatedFile>`,
+      "sflo:hasWorkingLocatedFile",
+    )
+    .replaceAll(
+      `<${SFLO_NAMESPACE}hasResourcePage>`,
+      "sflo:hasResourcePage",
+    )
+    .replaceAll(`<${SFLO_NAMESPACE}ResourcePage>`, "sflo:ResourcePage")
+    .replaceAll(`<${SFLO_NAMESPACE}LocatedFile>`, "sflo:LocatedFile");
+  for (
+    const path of [
+      referenceCatalogPath,
+      workingLocalRelativePath,
+      referenceCatalogPagePath,
+    ]
   ) {
-    throw new WeaveInputError(
-      `Current ReferenceCatalog block did not carry the expected working file for ${designatorPath}.`,
+    compactAppendTurtle = compactAppendTurtle.replaceAll(
+      `<${new URL(path, meshBase).href}>`,
+      `<${path}>`,
     );
   }
 
-  const blocksWithReferencePage = replaceSubjectBlock(
-    blocks,
-    referenceCatalogPath,
-    appendPredicateToSubjectBlock(
-      currentReferenceCatalogBlock,
-      `sflo:hasResourcePage <${referenceCatalogPagePath}>`,
-    ),
-  );
-  const finalBlocks = upsertSubjectBlockAfter(
-    blocksWithReferencePage,
-    referenceCatalogPath,
-    referenceCatalogPagePath,
-    renderResourcePageLocatedFileBlock(referenceCatalogPagePath),
-  );
-
-  return `${finalBlocks.join("\n\n")}\n`;
+  return `${
+    plan.outputTurtle.slice(0, -plan.appendTurtle.length)
+  }${compactAppendTurtle}`;
 }
 
 export function renderCurrentOnlyPageDefinitionWovenKnopInventoryTurtle(

--- a/src/core/weave/knop_inventory_renderers_test.ts
+++ b/src/core/weave/knop_inventory_renderers_test.ts
@@ -1,0 +1,113 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import { WeaveInputError } from "./errors.ts";
+import { renderCurrentOnlyReferenceCatalogWovenKnopInventoryTurtle } from "./knop_inventory_renderers.ts";
+
+const meshBase = "https://semantic-flow.github.io/mesh-alice-bio/";
+const designatorPath = "alice";
+const referencesFilePath = "alice/_knop/_references/references.ttl";
+const otherReferencesFilePath = "alice/_knop/_references/other-references.ttl";
+
+Deno.test("current-only ReferenceCatalog inventory append preserves the exact existing prefix", () => {
+  const currentKnopInventoryTurtle = `@base <${meshBase}> .
+@prefix ex: <https://example.org/weave-test/> .
+@prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .
+
+# Keep this hand-authored inventory context byte-for-byte.
+
+<alice/_knop/_references> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;
+  ex:curatedNote "unrelated fact" ;
+  sflo:hasWorkingLocatedFile <${referencesFilePath}> .
+`;
+
+  const result = renderCurrentOnlyReferenceCatalogWovenKnopInventoryTurtle(
+    meshBase,
+    currentKnopInventoryTurtle,
+    designatorPath,
+    referencesFilePath,
+  );
+
+  assert(result.startsWith(currentKnopInventoryTurtle));
+  const appendedSuffix = result.slice(currentKnopInventoryTurtle.length);
+  assertStringIncludes(
+    appendedSuffix,
+    "<alice/_knop/_references> sflo:hasResourcePage <alice/_knop/_references/index.html> .",
+  );
+  assertStringIncludes(
+    appendedSuffix,
+    "<alice/_knop/_references/index.html> a sflo:ResourcePage .",
+  );
+  assertStringIncludes(
+    appendedSuffix,
+    "<alice/_knop/_references/index.html> a sflo:LocatedFile .",
+  );
+  assertEquals(
+    appendedSuffix.includes(
+      "<https://semantic-flow.github.io/sflo/ontology/hasResourcePage>",
+    ),
+    false,
+  );
+});
+
+Deno.test("current-only ReferenceCatalog inventory no-op preserves exact bytes", () => {
+  const currentKnopInventoryTurtle = `@base <${meshBase}> .
+@prefix ex: <https://example.org/weave-test/> .
+@prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .
+
+# Deliberately retain this formatting and trailing blank line.
+
+<alice/_knop/_references> a sflo:RdfDocument, sflo:ReferenceCatalog, sflo:DigitalArtifact ;
+  sflo:hasResourcePage <alice/_knop/_references/index.html> ;
+  sflo:hasWorkingLocatedFile <${referencesFilePath}> ;
+  ex:curatedNote "keep me" .
+
+<alice/_knop/_references/index.html> a sflo:LocatedFile, sflo:ResourcePage .
+
+`;
+
+  const result = renderCurrentOnlyReferenceCatalogWovenKnopInventoryTurtle(
+    meshBase,
+    currentKnopInventoryTurtle,
+    designatorPath,
+    referencesFilePath,
+  );
+
+  assertEquals(result, currentKnopInventoryTurtle);
+});
+
+Deno.test("current-only ReferenceCatalog inventory conflict names requested and existing facts", () => {
+  const currentKnopInventoryTurtle = `@base <${meshBase}> .
+@prefix ex: <https://example.org/weave-test/> .
+@prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .
+
+<alice/_knop/_references> a sflo:ReferenceCatalog, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <${otherReferencesFilePath}> ;
+  ex:expectedWorkingFile <${referencesFilePath}> .
+`;
+
+  const error = assertThrows(
+    () =>
+      renderCurrentOnlyReferenceCatalogWovenKnopInventoryTurtle(
+        meshBase,
+        currentKnopInventoryTurtle,
+        designatorPath,
+        referencesFilePath,
+      ),
+    WeaveInputError,
+  );
+
+  assertStringIncludes(error.message, "Requested settled inventory fact");
+  assertStringIncludes(
+    error.message,
+    `<${meshBase}${referencesFilePath}>`,
+  );
+  assertStringIncludes(error.message, "conflicts with existing fact");
+  assertStringIncludes(
+    error.message,
+    `<${meshBase}${otherReferencesFilePath}>`,
+  );
+});


### PR DESCRIPTION
Bite 1 of `wa.task.2026.2026-05-17-append-onlyish-inventory` — the first production consumer migrated onto the existing `planInventoryAppend`. Brief and evidence audit are in that note.

## What

`renderCurrentOnlyReferenceCatalogWovenKnopInventoryTurtle` previously split the KnopInventory into subject blocks, replaced the ReferenceCatalog block, upserted a page block, and rejoined the whole document. It now routes through `planInventoryAppend`, so the operation:

- preserves the existing inventory **byte-for-byte as an exact prefix**,
- appends only genuinely missing settled facts,
- returns the **exact input bytes** on a semantic no-op,
- fails with both requested and existing facts named on a real conflict,
- treats only `sflo:hasWorkingLocatedFile` as single-valued — `hasResourcePage` is *not* functional in the core ontology (verified: plain `owl:ObjectProperty`).

The planner itself is untouched; this is a consumer migration.

## It also closed a false negative

The conflict test found a defect in the code being replaced: the old substring guard accepted the requested working locator appearing in an unrelated `ex:` predicate while a **different** locator was actually carried — so a genuine conflict passed silently. The new path refuses it.

## Fail-on-old, all three recorded

- Append: failed the exact-prefix assertion, because the old renderer rejoined blocks.
- No-op: failed byte equality — the old renderer reordered page types and dropped a trailing blank line.
- Conflict: threw nothing at all under the old guard.

New tests live in `src/core/weave/knop_inventory_renderers_test.ts`, deliberately kept out of `weave_test.ts` to avoid colliding with concurrent lanes. Full `deno task ci` and `deno task build:npm-lib` green.

## Not in this bite

Versioned ReferenceCatalog history, the PageDefinition twin, MeshInventory/payload/batch/progression refactors, and — flagged as its own correctness bite — the `resource_page_policy.ts` path that *deletes* disallowed settled page facts, a sharper violation of the append-onlyish contract than what this fixes.

Implemented by Codex (`codex exec`) as Kim under the standing grant; reviewed, gated, and landed by the planning seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHrFYeUefDr227gLuWWuq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Current-only ReferenceCatalog inventory rendering now adds requested catalog facts while preserving existing content.
  * Generated IRIs and predicates are normalized for consistent output.

* **Bug Fixes**
  * Conflicting requested and existing catalog facts now produce a clear input error.
  * Unchanged inventories remain byte-for-byte identical.

* **Tests**
  * Added coverage for fact appending, exact-prefix preservation, unchanged output, and conflict reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->