### PR TITLE
fix(weave): do not compact mesh IRIs into invalid sflo: prefixed names

### DIFF
--- a/src/core/weave/knop_support_renderers.ts
+++ b/src/core/weave/knop_support_renderers.ts
@@ -667,7 +667,16 @@ function renderNamedNodeTerm(
     return "a";
   }
   if (value.startsWith(SFLO_NAMESPACE)) {
-    return `sflo:${value.slice(SFLO_NAMESPACE.length)}`;
+    const localName = value.slice(SFLO_NAMESPACE.length);
+    // A mesh published under the SFLO vocabulary namespace — the sflo mesh
+    // itself, whose `ontology/` designator sits at the vocabulary IRI — has
+    // resources like `<…/sflo/ontology/_knop/_sources>`. Compacting those
+    // would emit `sflo:_knop/_sources`, and `/` is not legal in a Turtle
+    // prefixed name's local part, so the facts fail to re-parse. Fall through
+    // to a mesh-relative or absolute IRI in that case.
+    if (!localName.includes("/")) {
+      return `sflo:${localName}`;
+    }
   }
   if (meshBase !== undefined && value.startsWith(meshBase)) {
     return `<${value.slice(meshBase.length)}>`;

--- a/src/core/weave/knop_support_renderers_test.ts
+++ b/src/core/weave/knop_support_renderers_test.ts
@@ -282,3 +282,43 @@ function hasPredicate(quads: readonly Quad[], predicateIri: string): boolean {
 function parseQuads(turtle: string): Quad[] {
   return new Parser({ baseIRI: meshBase }).parse(turtle);
 }
+
+// A mesh whose designator path sits at the SFLO vocabulary namespace — the
+// sflo mesh itself, published at https://semantic-flow.github.io/sflo/ with
+// its ontology payload at `ontology/` — used to emit `sflo:_knop/_sources`
+// for its own resources. `/` is not legal in a Turtle prefixed name's local
+// part, so the carried facts failed to re-parse and every weave of that mesh
+// refused with "Could not parse carried Knop support facts Turtle."
+Deno.test("renderKnopInventoryWithPreservedSupportArtifacts preserves support facts when the mesh sits under the SFLO vocabulary namespace", () => {
+  const sfloMeshBase = "https://semantic-flow.github.io/sflo/";
+  const sfloKnopPath = "ontology/_knop";
+  const currentKnopInventoryTurtle = `@base <${sfloMeshBase}> .
+@prefix sflo: <${SFLO_NAMESPACE}> .
+
+<ontology/_knop> a sflo:Knop ;
+  sflo:hasKnopMetadata <ontology/_knop/_meta> ;
+  sflo:hasKnopInventory <ontology/_knop/_inventory> ;
+  sflo:hasKnopSourceRegistry <ontology/_knop/_sources> ;
+  sflo:hasWorkingKnopInventoryFile <ontology/_knop/_inventory/inventory.ttl> ;
+  sflo:hasPayloadArtifact <ontology> .
+
+<ontology/_knop/_sources> a sflo:KnopSourceRegistry, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <ontology/_knop/_sources/sources.ttl> .
+
+<ontology/_knop/_sources/sources.ttl> a sflo:LocatedFile, sflo:RdfDocument .
+`;
+
+  const rendered = renderKnopInventoryWithPreservedSupportArtifacts({
+    meshBase: sfloMeshBase,
+    currentKnopInventoryTurtle,
+    renderedKnopInventoryTurtle: currentKnopInventoryTurtle,
+    knopPath: sfloKnopPath,
+  });
+
+  // The result must re-parse, and must never contain a prefixed name whose
+  // local part carries a path separator.
+  const quads = new Parser({ baseIRI: sfloMeshBase }).parse(rendered);
+  assert(quads.length > 0);
+  assertFalse(/\bsflo:[^\s;,.]*\//.test(rendered));
+  assertStringIncludes(rendered, "ontology/_knop/_sources");
+});


### PR DESCRIPTION
Found by dogfooding: the sflo published-mesh regeneration (`wa.task.2026.2026-08-01_2032-regenerate-sflo-published-mesh`) could not weave a single payload.

## The defect

The sflo mesh is published at `https://semantic-flow.github.io/sflo/` and its ontology payload sits at the `ontology/` designator — so its own mesh resources have IRIs like `https://semantic-flow.github.io/sflo/ontology/_knop/_sources`. That prefix is *also* `SFLO_NAMESPACE`, the vocabulary namespace.

`renderNamedNodeTerm` compacted those mesh resources to `sflo:_knop/_sources`. A Turtle prefixed name's local part may not contain `/`, so the carried support facts Weave had just rendered failed to re-parse:

```
=== FAILED TURTLE ===
@prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .

sflo:_knop sflo:hasKnopSourceRegistry sflo:_knop/_sources .
...
=== N3 ERROR: Unexpected "sflo:_knop/_sources" on line 3.
```

Every weave of that mesh refused with `Could not parse carried Knop support facts Turtle.` sflo is plausibly the only affected mesh, because it is the one that self-hosts the vocabulary it is published under — which is likely why its current `gh-pages` state is a commit literally titled "lovely manual re-creation".

## The fix

Compact to `sflo:` only when the remaining local name contains no `/`; otherwise fall through to the existing mesh-relative or absolute IRI form. Deliberately surgical: no other mesh's generated bytes change, so there is no fixture churn.

## Evidence

- Fail-on-old recorded: the new regression fails against the unmodified renderer (`0 passed | 1 failed`) and passes with the fix.
- The regression asserts the carried facts re-parse and that no emitted prefixed name has a separator in its local part.
- Full `deno task ci` and `deno task build:npm-lib` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHrFYeUefDr227gLuWWuq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Turtle rendering for SFLO IRIs whose local names contain path separators.
  * Preserved support-fact data and source registry paths when using the SFLO vocabulary namespace.
  * Ensured generated Turtle remains valid and can be parsed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->