### PR TITLE
build(npm-lib): emit ESM only, dropping the CJS output

### DIFF
--- a/documentation/notes/release-notes.v0.7.0.md
+++ b/documentation/notes/release-notes.v0.7.0.md
@@ -29,7 +29,11 @@ Three of the four changes are labeled `fix`, but the batch dispatch is a genuine
 - **Cardinality: only `hasWorkingLocatedFile` is treated as single-valued** on this path. `hasResourcePage` is not functional in the ontology and is no longer collapsed as if it were.
 - **Output shape: Turtle IRI compaction is narrower.** IRIs whose local name contains a path separator now render in mesh-relative or absolute form instead of a `sflo:` prefixed name. Scoped by construction to meshes with resources under the vocabulary namespace — no other mesh's output changes.
 - **Acceptance: nested extraction sources no longer require root Knop facts.** Meshes that `0.6.0` refused with `settled extracted-knop pre-weave mesh inventory shape` now weave. No previously-accepted mesh changes behavior, and no `_knop` artifacts are synthesized for grouping segments.
-- No API, CLI routing, packaging, or `versionPayloads`/`validateMesh` contract changes. `@semantic-flow/weave-lib` ships at `0.7.0` with an unchanged surface.
+- **BREAKING for CommonJS consumers: `@semantic-flow/weave-lib` is now ESM-only.** The dnt build no longer emits the `script/` (CJS) output, so the package exposes `exports: { ".": { "import": "./esm/api/mod.js" } }` with no `require` entry and no `main`. Node 20 — already this package's declared engine floor — supports ESM natively, and the off-tree Node contract smoke already exercised the ESM path, so the API surface itself is unchanged. `import { validateMesh, versionPayloads } from "@semantic-flow/weave-lib"` is unaffected; `require("@semantic-flow/weave-lib")` no longer resolves.
+
+  Why now: dependencies the page-generation surface needs are ESM-only upstream. This was already latent — the previously generated CJS bundle contained `require("shiki")`, and Shiki is ESM-only; it was invisible only because `src/api/mod.ts` exports validation and versioning, not page generation. Dropping CJS resolves the existing inconsistency and unblocks the Markdown pipeline work.
+
+- No API, CLI routing, or `versionPayloads`/`validateMesh` contract changes. `@semantic-flow/weave-lib` ships at `0.7.0` with an unchanged API surface — only its module format changed.
 
 ## Artifacts
 

--- a/scripts/build-npm-lib.ts
+++ b/scripts/build-npm-lib.ts
@@ -65,6 +65,11 @@ export async function buildNpmLibPackage(
   await build({
     entryPoints: [join(options.root, "src/api/mod.ts")],
     outDir,
+    // ESM-only. Several dependencies the page-generation surface needs are
+    // ESM-only upstream (shiki today; a unified/remark/rehype pipeline later),
+    // so a CJS build cannot express them as external `require()` dependencies.
+    // Node 20 — already this package's engine floor — supports ESM natively.
+    scriptModule: false,
     shims: {
       deno: true,
     },


### PR DESCRIPTION
One line of dnt config (`scriptModule: false`) plus a release-note entry. No source changes.

## What changed

| | before | after |
|---|---|---|
| `main` | `./script/api/mod.js` | *(absent)* |
| `module` | `./esm/api/mod.js` | `./esm/api/mod.js` |
| `exports["."]` | `{ import, require }` | `{ import }` |
| output dirs | `esm/` + `script/` | `esm/` |

`esm/package.json` carries `{"type":"module"}`, and no `require()` survives anywhere in the emitted output.

## This fixes an existing inconsistency, it doesn't introduce a constraint

The previously generated CJS bundle contained `require("shiki")` — and Shiki is ESM-only upstream. That build was already incapable of working as CJS for anything touching page generation. It went unnoticed because `src/api/mod.ts` exports validation and versioning only, so the broken path was never loaded.

Dropping CJS makes the package honest about what it can actually do, and removes the packaging gate on the Markdown pipeline work, whose candidate dependencies are ESM-only.

## Breaking, narrowly

`require("@semantic-flow/weave-lib")` no longer resolves. The API surface is unchanged and `import { validateMesh, versionPayloads } from "@semantic-flow/weave-lib"` is unaffected. Node 20 is already the declared engine floor.

Worth confirming with Stagecraft that they consume via `import` — that's the one consumer this could reach.

## Why it's in v0.7.0 rather than 0.8.0

v0.7.0 is prepared but unpublished (no tag; npm still serves 0.6.0). Folding it in avoids consumers adopting CJS in 0.7.0 and losing it one release later. The release notes' Breaking Or Changed Behavior section now names it.

**This supersedes the earlier rehearsal** — the draft `v0.7.0` release was built at `812ab77`. A fresh `Release Manual` rehearsal is needed on the new merge commit before publishing.

## Verification

- `deno task build:npm-lib` — ESM-only output confirmed
- `deno task smoke:npm-lib` — passed: 2 payloads versioned and `validateMesh` returned settled/defect contract results under real Node, off-tree. This smoke already used `type: "module"` and `.mjs` consumers, so it was exercising the ESM path before this change
- `deno task ci` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that the package is now ESM-only.
  * Clarified that import APIs and CLI contracts remain unchanged.

* **Build**
  * Updated the package distribution to use ESM exclusively.
  * Removed CommonJS-specific outputs and entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->