### PR TITLE
feat(weave): batch untargeted extracted-term first-payload weave

### DIFF
--- a/src/core/weave/mesh_inventory_renderers.ts
+++ b/src/core/weave/mesh_inventory_renderers.ts
@@ -16,6 +16,7 @@ import {
 import type { RepositorySourceFloatingLocator } from "./source_models.ts";
 import {
   findSubjectBlockIndex,
+  getSubjectPathFromBlock,
   normalizeMeshInventoryHeader,
   replaceSubjectBlock,
   splitTurtleBlocks,
@@ -361,6 +362,161 @@ export function renderBatchedFirstPayloadWovenMeshInventoryTurtle(
         ),
     currentMeshInventoryTurtle,
   );
+}
+
+export function renderBatchedFirstExtractedKnopWovenMeshInventoryTurtle(
+  currentMeshInventoryTurtle: string,
+  _meshBase: string,
+  designatorPaths: readonly string[],
+  meshInventoryProgression: MeshInventoryProgression | undefined,
+): string {
+  const orderedDesignatorPaths = [...new Set(designatorPaths)].sort((
+    left,
+    right,
+  ) => left.localeCompare(right));
+  let blocks = renderBatchedFirstExtractedKnopTargetBlocks(
+    currentMeshInventoryTurtle,
+    orderedDesignatorPaths,
+  );
+  if (meshInventoryProgression === undefined) {
+    return `${blocks.join("\n\n")}\n`;
+  }
+
+  const historyPath = meshInventoryProgression.historyPath;
+  const nextStatePath = meshInventoryProgression.nextStatePath;
+  const nextManifestationPath = `${nextStatePath}/ttl`;
+  blocks = replaceSubjectBlock(
+    blocks,
+    "_mesh/_inventory",
+    renderMeshInventoryArtifactBlock(historyPath),
+  );
+  blocks = replaceSubjectBlock(
+    blocks,
+    historyPath,
+    renderMeshInventoryHistoryBlock(
+      historyPath,
+      meshInventoryProgression.nextStateOrdinal,
+      nextStatePath,
+    ),
+  );
+  blocks = upsertSubjectBlockAfter(
+    blocks,
+    meshInventoryProgression.latestManifestationPath,
+    nextStatePath,
+    renderMeshInventoryStateBlock(
+      nextStatePath,
+      meshInventoryProgression.nextStateOrdinal,
+      meshInventoryProgression.latestStatePath,
+    ),
+  );
+  blocks = upsertSubjectBlockAfter(
+    blocks,
+    nextStatePath,
+    nextManifestationPath,
+    renderMeshInventoryStateManifestationBlock(nextStatePath),
+  );
+  blocks = upsertSubjectBlockAfter(
+    blocks,
+    `${meshInventoryProgression.latestManifestationPath}/inventory.ttl`,
+    `${nextManifestationPath}/inventory.ttl`,
+    renderLocatedFileBlock(`${nextManifestationPath}/inventory.ttl`),
+  );
+  blocks = upsertSubjectBlockAfter(
+    blocks,
+    `${meshInventoryProgression.latestManifestationPath}/index.html`,
+    `${nextStatePath}/index.html`,
+    renderResourcePageLocatedFileBlock(`${nextStatePath}/index.html`),
+  );
+  blocks = upsertSubjectBlockAfter(
+    blocks,
+    `${nextStatePath}/index.html`,
+    `${nextManifestationPath}/index.html`,
+    renderResourcePageLocatedFileBlock(`${nextManifestationPath}/index.html`),
+  );
+
+  return `${blocks.join("\n\n")}\n`;
+}
+
+function renderBatchedFirstExtractedKnopTargetBlocks(
+  currentMeshInventoryTurtle: string,
+  designatorPaths: readonly string[],
+): string[] {
+  const targetSubjectPaths = new Set<string>();
+  const meshMembershipBlockByKnopPath = new Map<string, string>();
+  for (const designatorPath of designatorPaths) {
+    const knopPath = toKnopPath(designatorPath);
+    targetSubjectPaths.add(designatorPath);
+    targetSubjectPaths.add(knopPath);
+    targetSubjectPaths.add(`${knopPath}/_inventory/inventory.ttl`);
+    targetSubjectPaths.add(toDesignatorResourcePagePath(designatorPath));
+    targetSubjectPaths.add(`${knopPath}/index.html`);
+    meshMembershipBlockByKnopPath.set(
+      knopPath,
+      `<_mesh> sflo:hasKnop <${knopPath}> .`,
+    );
+  }
+  const targetMeshMembershipBlocks = new Set(
+    meshMembershipBlockByKnopPath.values(),
+  );
+  const initialBlocks = normalizeMeshInventoryHeader(
+    splitTurtleBlocks(currentMeshInventoryTurtle),
+  );
+  const presentMeshMembershipBlocks = new Set(
+    initialBlocks.filter((block) => targetMeshMembershipBlocks.has(block)),
+  );
+  const blocks = initialBlocks.filter((block) => {
+    if (targetMeshMembershipBlocks.has(block)) {
+      return false;
+    }
+    const subjectPath = getSubjectPathFromBlock(block);
+    return subjectPath === undefined || !targetSubjectPaths.has(subjectPath);
+  });
+  const resourceBlocks: string[] = [];
+  const locatedFileBlocks: string[] = [];
+  const pageBlocks: string[] = [];
+
+  for (const designatorPath of designatorPaths) {
+    const knopPath = toKnopPath(designatorPath);
+    const designatorPagePath = toDesignatorResourcePagePath(designatorPath);
+    const membershipBlock = meshMembershipBlockByKnopPath.get(knopPath)!;
+    if (presentMeshMembershipBlocks.has(membershipBlock)) {
+      resourceBlocks.push(membershipBlock);
+    }
+    resourceBlocks.push(
+      renderMeshIdentifierBlock(designatorPath),
+      renderMeshKnopBlockWithResourcePage(knopPath),
+    );
+    locatedFileBlocks.push(
+      renderLocatedFileBlock(`${knopPath}/_inventory/inventory.ttl`),
+    );
+    pageBlocks.push(
+      renderResourcePageLocatedFileBlock(designatorPagePath),
+      renderResourcePageLocatedFileBlock(`${knopPath}/index.html`),
+    );
+  }
+
+  insertBlocksAfterSubject(blocks, "_mesh", resourceBlocks);
+  insertBlocksAfterSubject(
+    blocks,
+    "_mesh/_inventory/inventory.ttl",
+    locatedFileBlocks,
+  );
+  insertBlocksAfterSubject(blocks, "_mesh/index.html", pageBlocks);
+  return blocks;
+}
+
+function insertBlocksAfterSubject(
+  blocks: string[],
+  anchorSubjectPath: string,
+  additions: readonly string[],
+): void {
+  const anchorIndex = findSubjectBlockIndex(blocks, anchorSubjectPath);
+  if (anchorIndex === -1) {
+    throw new WeaveInputError(
+      `Current mesh inventory did not contain anchor subject block <${anchorSubjectPath}>.`,
+    );
+  }
+  blocks.splice(anchorIndex + 1, 0, ...additions);
 }
 
 export function renderFirstPayloadWovenCurrentOnlyMeshInventoryTurtle(

--- a/src/core/weave/planning_models.ts
+++ b/src/core/weave/planning_models.ts
@@ -28,4 +28,5 @@ export interface WeavePlan {
   createdBinaryFiles?: readonly PlannedBinaryFile[];
   updatedFiles: readonly PlannedFile[];
   createdPages: readonly ResourcePageModel[];
+  regeneratedPagePaths?: readonly string[];
 }

--- a/src/core/weave/shape_assertions.ts
+++ b/src/core/weave/shape_assertions.ts
@@ -261,18 +261,74 @@ export function assertCurrentMeshInventoryShapeForFirstExtractedKnopWeave(
     "workingLocalRelativePath" | "repositorySourceFloatingLocator"
   >,
 ): void {
-  const sourceKnopPath = toKnopPath(sourcePayloadDesignatorPath);
-  const knopPath = toKnopPath(designatorPath);
-  const designatorPagePath = toDesignatorResourcePagePath(designatorPath);
-  const sourcePayloadPagePath = toDesignatorResourcePagePath(
-    sourcePayloadDesignatorPath,
-  );
   const errorMessage =
     `The current local weave slice only supports the settled extracted-knop pre-weave mesh inventory shape for ${designatorPath}.`;
   const quads = parseWeaveShapeQuads(
     meshBase,
     currentMeshInventoryTurtle,
     errorMessage,
+  );
+  assertCurrentMeshInventoryQuadsForFirstExtractedKnopWeave(
+    quads,
+    meshBase,
+    meshInventoryProgression,
+    designatorPath,
+    sourcePayloadDesignatorPath,
+    sourcePayloadArtifact,
+    errorMessage,
+  );
+}
+
+export function assertCurrentMeshInventoryShapeForFirstExtractedKnopBatchWeave(
+  meshBase: string,
+  currentMeshInventoryTurtle: string,
+  meshInventoryProgression: MeshInventoryProgression | undefined,
+  targets: readonly {
+    designatorPath: string;
+    sourcePayloadDesignatorPath: string;
+    sourcePayloadArtifact: Pick<
+      ReferenceTargetSourcePayloadArtifact,
+      "workingLocalRelativePath" | "repositorySourceFloatingLocator"
+    >;
+  }[],
+): void {
+  const quads = parseWeaveShapeQuads(
+    meshBase,
+    currentMeshInventoryTurtle,
+    "Could not parse the current MeshInventory for an untargeted extracted-Knop batch weave.",
+  );
+  for (const target of targets) {
+    const errorMessage =
+      `The current local weave slice only supports the settled extracted-knop pre-weave mesh inventory shape for ${target.designatorPath}.`;
+    assertCurrentMeshInventoryQuadsForFirstExtractedKnopWeave(
+      quads,
+      meshBase,
+      meshInventoryProgression,
+      target.designatorPath,
+      target.sourcePayloadDesignatorPath,
+      target.sourcePayloadArtifact,
+      errorMessage,
+    );
+  }
+}
+
+function assertCurrentMeshInventoryQuadsForFirstExtractedKnopWeave(
+  quads: readonly Quad[],
+  meshBase: string,
+  meshInventoryProgression: MeshInventoryProgression | undefined,
+  designatorPath: string,
+  sourcePayloadDesignatorPath: string,
+  sourcePayloadArtifact: Pick<
+    ReferenceTargetSourcePayloadArtifact,
+    "workingLocalRelativePath" | "repositorySourceFloatingLocator"
+  >,
+  errorMessage: string,
+): void {
+  const sourceKnopPath = toKnopPath(sourcePayloadDesignatorPath);
+  const knopPath = toKnopPath(designatorPath);
+  const designatorPagePath = toDesignatorResourcePagePath(designatorPath);
+  const sourcePayloadPagePath = toDesignatorResourcePagePath(
+    sourcePayloadDesignatorPath,
   );
 
   assertHasNamedNodeFacts(quads, meshBase, errorMessage, [

--- a/src/core/weave/version_plan.ts
+++ b/src/core/weave/version_plan.ts
@@ -6,6 +6,7 @@ export interface VersionPlan {
   createdFiles: readonly PlannedFile[];
   createdBinaryFiles?: readonly PlannedBinaryFile[];
   updatedFiles: readonly PlannedFile[];
+  regeneratedPagePaths?: readonly string[];
 }
 
 export interface PlannedPayloadSnapshot {

--- a/src/core/weave/weave.ts
+++ b/src/core/weave/weave.ts
@@ -41,6 +41,7 @@ import {
   renderLaterPayloadWovenKnopInventoryTurtle,
 } from "./payload_renderers.ts";
 import {
+  renderBatchedFirstExtractedKnopWovenMeshInventoryTurtle,
   renderBatchedFirstPayloadWovenMeshInventoryTurtle,
   renderFirstKnopWovenMeshInventoryTurtle,
   renderFirstPayloadWovenCurrentOnlyMeshInventoryTurtle,
@@ -74,6 +75,7 @@ import {
   resolveCurrentMeshInventoryProgressionForFirstPayloadWeave,
   resolvePageDefinitionWeaveProgression,
 } from "./progression_resolvers.ts";
+import type { MeshInventoryProgression } from "./progression_models.ts";
 import {
   buildCurrentOnlyPageDefinitionWeavePages,
   buildCurrentOnlyReferenceCatalogWeavePages,
@@ -98,6 +100,7 @@ import {
   assertCurrentKnopInventoryShapeForSubsequentPageDefinitionWeave,
   assertCurrentKnopInventoryWithoutHistory,
   assertCurrentKnopMetadataShape,
+  assertCurrentMeshInventoryShapeForFirstExtractedKnopBatchWeave,
   assertCurrentMeshInventoryShapeForFirstExtractedKnopWeave,
   assertCurrentMeshInventoryShapeForFirstReferenceCatalogWeave,
   assertCurrentPayloadArtifactShape,
@@ -229,13 +232,33 @@ export function planWeave(input: PlanWeaveInput): WeavePlan {
   if (weaveableKnops.length !== 1) {
     const isUntargetedFirstPayloadBatch = requestedTargets.length === 0 &&
       !overwriteExistingState &&
-      weaveableKnops.every((selection) =>
-        classifyWeaveSlice(
-          meshBase,
-          selection.candidate,
-          selection.target,
-        ) === "firstPayloadWeave"
+      isHomogeneousBatchSlice(
+        meshBase,
+        weaveableKnops,
+        "firstPayloadWeave",
       );
+    const isUntargetedFirstExtractedKnopBatch = requestedTargets.length === 0 &&
+      !overwriteExistingState &&
+      isHomogeneousBatchSlice(
+        meshBase,
+        weaveableKnops,
+        "firstExtractedKnopWeave",
+      );
+    if (isUntargetedFirstExtractedKnopBatch) {
+      const plan = planUntargetedFirstExtractedKnopBatchWeave(
+        meshBase,
+        input.currentMeshInventoryTurtle,
+        input.currentMeshMetadataTurtle,
+        weaveableKnops,
+        input.supportHistoryPolicies,
+      );
+
+      return applyResourcePageGenerationPolicies(plan, {
+        config: input.resourcePageGenerationConfig,
+        policies: input.resourcePageGenerationPolicies,
+        explicitRequest: false,
+      });
+    }
     if (
       !overwriteExistingState &&
       (requestedTargets.length > 1 || isUntargetedFirstPayloadBatch)
@@ -351,6 +374,20 @@ export function planWeave(input: PlanWeaveInput): WeavePlan {
     policies: input.resourcePageGenerationPolicies,
     explicitRequest: requestedTargets.length > 0,
   });
+}
+
+function isHomogeneousBatchSlice(
+  meshBase: string,
+  selections: readonly SelectedWeaveableKnopCandidate[],
+  expectedSlice: "firstPayloadWeave" | "firstExtractedKnopWeave",
+): boolean {
+  return selections.every((selection) =>
+    classifyWeaveSlice(
+      meshBase,
+      selection.candidate,
+      selection.target,
+    ) === expectedSlice
+  );
 }
 
 export function planVersion(input: PlanWeaveInput): VersionPlan {
@@ -605,6 +642,105 @@ interface FirstPayloadBatchEntry {
   >;
 }
 
+function planUntargetedFirstExtractedKnopBatchWeave(
+  meshBase: string,
+  currentMeshInventoryTurtle: string,
+  currentMeshMetadataTurtle: string | undefined,
+  selectedWeaveableKnops: readonly SelectedWeaveableKnopCandidate[],
+  supportHistoryPolicies?: WeaveSupportHistoryPolicies,
+): WeavePlan {
+  const selections = [...selectedWeaveableKnops].sort((left, right) =>
+    left.candidate.designatorPath.localeCompare(right.candidate.designatorPath)
+  );
+  const plans: WeavePlan[] = [];
+  const versionMeshInventory = shouldMaterializeSupportHistory(
+    supportHistoryPolicies?.meshInventory ?? "versioned",
+  );
+  const meshInventoryProgression = versionMeshInventory
+    ? resolveCurrentMeshInventoryProgressionForFirstKnopWeave(
+      meshBase,
+      currentMeshInventoryTurtle,
+      currentMeshMetadataTurtle,
+      selections[0]!.candidate.designatorPath,
+    )
+    : undefined;
+  assertCurrentMeshInventoryShapeForFirstExtractedKnopBatchWeave(
+    meshBase,
+    currentMeshInventoryTurtle,
+    meshInventoryProgression,
+    selections.map((selection) => {
+      const source = selection.candidate
+        .referenceTargetSourcePayloadArtifact!;
+      return {
+        designatorPath: selection.candidate.designatorPath,
+        sourcePayloadDesignatorPath: source.designatorPath,
+        sourcePayloadArtifact: source,
+      };
+    }),
+  );
+
+  for (const selection of selections) {
+    const candidate = selection.candidate;
+    const designatorPath = candidate.designatorPath;
+    const knopPath = toKnopPath(designatorPath);
+
+    withBatchTargetDiagnostic(designatorPath, () => {
+      if (selection.target !== undefined) {
+        throw new WeaveInputError(
+          "Untargeted extracted-Knop batching does not accept explicit targets.",
+        );
+      }
+      assertCurrentKnopMetadataShape(
+        meshBase,
+        candidate.currentKnopMetadataTurtle,
+        designatorPath,
+        knopPath,
+      );
+      assertCurrentKnopInventoryBaseShape(
+        meshBase,
+        candidate.currentKnopInventoryTurtle,
+        knopPath,
+      );
+      if (
+        classifyWeaveSlice(meshBase, candidate) !==
+          "firstExtractedKnopWeave"
+      ) {
+        throw new WeaveInputError(
+          `Untargeted extracted-Knop batch candidate ${designatorPath} is not in the first extracted-Knop weave slice.`,
+        );
+      }
+
+      plans.push(planFirstExtractedKnopWeave(
+        meshBase,
+        currentMeshInventoryTurtle,
+        currentMeshMetadataTurtle,
+        candidate,
+        supportHistoryPolicies,
+        {
+          includeSharedMeshInventoryFiles: false,
+          batchMeshInventoryProgression: meshInventoryProgression,
+        },
+      ));
+    });
+  }
+
+  const mergedMeshInventoryTurtle =
+    renderBatchedFirstExtractedKnopWovenMeshInventoryTurtle(
+      currentMeshInventoryTurtle,
+      meshBase,
+      selections.map((selection) => selection.candidate.designatorPath),
+      meshInventoryProgression,
+    );
+
+  return mergeFirstWeaveBatchPlans(
+    meshBase,
+    currentMeshMetadataTurtle,
+    plans,
+    meshInventoryProgression,
+    mergedMeshInventoryTurtle,
+  );
+}
+
 function planExplicitPayloadBatchWeave(
   meshBase: string,
   currentMeshInventoryTurtle: string,
@@ -792,13 +928,6 @@ function mergePayloadBatchPlans(
   plans: readonly WeavePlan[],
   firstPayloadEntries: readonly FirstPayloadBatchEntry[],
 ): WeavePlan {
-  const createdFiles: PlannedFile[] = [];
-  const createdBinaryFiles: PlannedBinaryFile[] = [];
-  const updatedFiles: PlannedFile[] = [];
-  const createdPages: ResourcePageModel[] = [];
-  const createdPaths = new Set<string>();
-  const updatedPaths = new Set<string>();
-  const pagePaths = new Set<string>();
   const firstPayloadProgression = resolveBatchMeshInventoryProgression(
     firstPayloadEntries,
   );
@@ -818,9 +947,33 @@ function mergePayloadBatchPlans(
       firstPayloadProgression,
     );
 
-  if (firstPayloadProgression && mergedMeshInventoryTurtle) {
+  return mergeFirstWeaveBatchPlans(
+    meshBase,
+    currentMeshMetadataTurtle,
+    plans,
+    firstPayloadProgression,
+    mergedMeshInventoryTurtle,
+  );
+}
+
+function mergeFirstWeaveBatchPlans(
+  meshBase: string,
+  currentMeshMetadataTurtle: string | undefined,
+  plans: readonly WeavePlan[],
+  meshInventoryProgression: MeshInventoryProgression | undefined,
+  mergedMeshInventoryTurtle: string | undefined,
+): WeavePlan {
+  const createdFiles: PlannedFile[] = [];
+  const createdBinaryFiles: PlannedBinaryFile[] = [];
+  const updatedFiles: PlannedFile[] = [];
+  const createdPages: ResourcePageModel[] = [];
+  const createdPaths = new Set<string>();
+  const updatedPaths = new Set<string>();
+  const pagePaths = new Set<string>();
+
+  if (meshInventoryProgression && mergedMeshInventoryTurtle) {
     addCreatedFile(createdFiles, createdPaths, updatedPaths, {
-      path: `${firstPayloadProgression.nextStatePath}/ttl/inventory.ttl`,
+      path: `${meshInventoryProgression.nextStatePath}/ttl/inventory.ttl`,
       contents: mergedMeshInventoryTurtle,
     });
   }
@@ -861,12 +1014,12 @@ function mergePayloadBatchPlans(
     }
   }
 
-  if (firstPayloadProgression) {
+  if (meshInventoryProgression) {
     addUpdatedFile(updatedFiles, updatedPaths, createdPaths, {
       path: "_mesh/_meta/meta.ttl",
       contents: renderMeshMetadataWithMeshInventoryProgression(
         currentMeshMetadataTurtle,
-        firstPayloadProgression,
+        meshInventoryProgression,
       ),
     });
   }
@@ -882,15 +1035,15 @@ function mergePayloadBatchPlans(
 }
 
 function resolveBatchMeshInventoryProgression(
-  firstPayloadEntries: readonly FirstPayloadBatchEntry[],
-): FirstPayloadBatchEntry["meshInventoryProgression"] {
-  const progressions = firstPayloadEntries
+  entries: readonly { meshInventoryProgression?: MeshInventoryProgression }[],
+): MeshInventoryProgression | undefined {
+  const progressions = entries
     .map((entry) => entry.meshInventoryProgression)
     .filter((progression) => progression !== undefined);
   if (progressions.length === 0) {
     return undefined;
   }
-  if (progressions.length !== firstPayloadEntries.length) {
+  if (progressions.length !== entries.length) {
     throw new WeaveInputError(
       "Multi-target payload weave found conflicting MeshInventory history policies across requested targets.",
       "progression-conflict",
@@ -911,8 +1064,8 @@ function resolveBatchMeshInventoryProgression(
 }
 
 function meshInventoryProgressionsEqual(
-  left: NonNullable<FirstPayloadBatchEntry["meshInventoryProgression"]>,
-  right: NonNullable<FirstPayloadBatchEntry["meshInventoryProgression"]>,
+  left: MeshInventoryProgression,
+  right: MeshInventoryProgression,
 ): boolean {
   return left.historyPath === right.historyPath &&
     left.latestStatePath === right.latestStatePath &&
@@ -1352,6 +1505,10 @@ function planFirstExtractedKnopWeave(
   currentMeshMetadataTurtle: string | undefined,
   candidate: WeaveableKnopCandidate,
   supportHistoryPolicies?: WeaveSupportHistoryPolicies,
+  options: {
+    includeSharedMeshInventoryFiles?: boolean;
+    batchMeshInventoryProgression?: MeshInventoryProgression;
+  } = {},
 ): WeavePlan {
   const designatorPath = candidate.designatorPath;
   const knopPath = toKnopPath(designatorPath);
@@ -1363,14 +1520,18 @@ function planFirstExtractedKnopWeave(
   const versionMeshInventory = shouldMaterializeSupportHistory(
     meshInventoryHistoryPolicy,
   );
-  const meshInventoryProgression = versionMeshInventory
-    ? resolveCurrentMeshInventoryProgressionForFirstKnopWeave(
-      meshBase,
-      currentMeshInventoryTurtle,
-      currentMeshMetadataTurtle,
-      designatorPath,
-    )
-    : undefined;
+  const batchMeshInventoryShapeAlreadyAsserted =
+    options.includeSharedMeshInventoryFiles === false;
+  const meshInventoryProgression = batchMeshInventoryShapeAlreadyAsserted
+    ? options.batchMeshInventoryProgression
+    : (versionMeshInventory
+      ? resolveCurrentMeshInventoryProgressionForFirstKnopWeave(
+        meshBase,
+        currentMeshInventoryTurtle,
+        currentMeshMetadataTurtle,
+        designatorPath,
+      )
+      : undefined);
   const knopMetadataHistoryPolicy = supportHistoryPolicies?.knopMetadata ??
     "versioned";
   const versionKnopMetadata = shouldMaterializeSupportHistory(
@@ -1382,14 +1543,16 @@ function planFirstExtractedKnopWeave(
     knopInventoryHistoryPolicy,
   );
 
-  assertCurrentMeshInventoryShapeForFirstExtractedKnopWeave(
-    meshBase,
-    currentMeshInventoryTurtle,
-    meshInventoryProgression,
-    designatorPath,
-    referenceTargetSourcePayloadArtifact.designatorPath,
-    referenceTargetSourcePayloadArtifact,
-  );
+  if (!batchMeshInventoryShapeAlreadyAsserted) {
+    assertCurrentMeshInventoryShapeForFirstExtractedKnopWeave(
+      meshBase,
+      currentMeshInventoryTurtle,
+      meshInventoryProgression,
+      designatorPath,
+      referenceTargetSourcePayloadArtifact.designatorPath,
+      referenceTargetSourcePayloadArtifact,
+    );
+  }
   assertCurrentKnopInventoryShapeForFirstExtractedKnopWeave(
     meshBase,
     candidate.currentKnopInventoryTurtle,
@@ -1408,17 +1571,21 @@ function planFirstExtractedKnopWeave(
     referenceTargetSourcePayloadArtifact,
   );
 
-  const wovenMeshInventoryTurtle = meshInventoryProgression === undefined
-    ? renderFirstPayloadWovenCurrentOnlyMeshInventoryTurtle(
-      currentMeshInventoryTurtle,
-      meshBase,
-      designatorPath,
-    )
-    : renderGenericFirstExtractedKnopWovenMeshInventoryTurtle(
-      currentMeshInventoryTurtle,
-      designatorPath,
-      meshInventoryProgression,
-    );
+  const includeSharedMeshInventoryFiles =
+    options.includeSharedMeshInventoryFiles !== false;
+  const wovenMeshInventoryTurtle = includeSharedMeshInventoryFiles
+    ? (meshInventoryProgression === undefined
+      ? renderFirstPayloadWovenCurrentOnlyMeshInventoryTurtle(
+        currentMeshInventoryTurtle,
+        meshBase,
+        designatorPath,
+      )
+      : renderGenericFirstExtractedKnopWovenMeshInventoryTurtle(
+        currentMeshInventoryTurtle,
+        designatorPath,
+        meshInventoryProgression,
+      ))
+    : undefined;
   const wovenKnopInventoryTurtle =
     renderKnopInventoryWithPreservedSupportArtifacts({
       meshBase,
@@ -1451,10 +1618,13 @@ function planFirstExtractedKnopWeave(
     meshBase,
     wovenDesignatorPaths: [designatorPath],
     createdFiles: [
-      ...(meshInventoryProgression === undefined ? [] : [{
-        path: `${meshInventoryProgression.nextStatePath}/ttl/inventory.ttl`,
-        contents: wovenMeshInventoryTurtle,
-      }]),
+      ...(meshInventoryProgression === undefined ||
+          wovenMeshInventoryTurtle === undefined
+        ? []
+        : [{
+          path: `${meshInventoryProgression.nextStatePath}/ttl/inventory.ttl`,
+          contents: wovenMeshInventoryTurtle,
+        }]),
       ...(versionKnopMetadata
         ? [{
           path: `${knopPath}/_meta/_history001/_s0001/ttl/meta.ttl`,
@@ -1502,10 +1672,10 @@ function planFirstExtractedKnopWeave(
         : []),
     ],
     updatedFiles: [
-      {
+      ...(wovenMeshInventoryTurtle === undefined ? [] : [{
         path: "_mesh/_inventory/inventory.ttl",
         contents: wovenMeshInventoryTurtle,
-      },
+      }]),
       {
         path: `${knopPath}/_inventory/inventory.ttl`,
         contents: wovenKnopInventoryTurtle,
@@ -1515,29 +1685,35 @@ function planFirstExtractedKnopWeave(
           .sourceRegistryWorkingLocalRelativePath!,
         contents: exactSourceRegistryTurtle,
       }]),
-      ...(meshInventoryProgression === undefined ? [] : [{
-        path: "_mesh/_inventory/_history001/index.html",
-        contents: renderArtifactHistoryIndexPage(meshBase, {
-          pagePath: "_mesh/_inventory/_history001/index.html",
-          description:
-            "Resource page for the current explicit history of the MeshInventory artifact.",
-          artifactLabel: "Inventory artifact",
-          workingLocalRelativePath: "_mesh/_inventory/inventory.ttl",
-          states: [
-            { segment: "_s0001", latest: false },
-            { segment: "_s0002", latest: false },
-            { segment: "_s0003", latest: false },
-            { segment: "_s0004", latest: true },
-          ],
-        }),
-      }]),
-      ...(meshInventoryProgression === undefined ? [] : [{
-        path: "_mesh/_meta/meta.ttl",
-        contents: renderMeshMetadataWithMeshInventoryProgression(
-          currentMeshMetadataTurtle,
-          meshInventoryProgression,
-        ),
-      }]),
+      ...(meshInventoryProgression === undefined ||
+          !includeSharedMeshInventoryFiles
+        ? []
+        : [{
+          path: "_mesh/_inventory/_history001/index.html",
+          contents: renderArtifactHistoryIndexPage(meshBase, {
+            pagePath: "_mesh/_inventory/_history001/index.html",
+            description:
+              "Resource page for the current explicit history of the MeshInventory artifact.",
+            artifactLabel: "Inventory artifact",
+            workingLocalRelativePath: "_mesh/_inventory/inventory.ttl",
+            states: [
+              { segment: "_s0001", latest: false },
+              { segment: "_s0002", latest: false },
+              { segment: "_s0003", latest: false },
+              { segment: "_s0004", latest: true },
+            ],
+          }),
+        }]),
+      ...(meshInventoryProgression === undefined ||
+          !includeSharedMeshInventoryFiles
+        ? []
+        : [{
+          path: "_mesh/_meta/meta.ttl",
+          contents: renderMeshMetadataWithMeshInventoryProgression(
+            currentMeshMetadataTurtle,
+            meshInventoryProgression,
+          ),
+        }]),
     ],
     createdPages: buildFirstExtractedKnopWeavePages(
       designatorPath,

--- a/src/core/weave/weave.ts
+++ b/src/core/weave/weave.ts
@@ -87,6 +87,7 @@ import {
   buildSubsequentPageDefinitionWeavePages,
 } from "./resource_page_builders.ts";
 import type { ResourcePageModel } from "./resource_page_models.ts";
+import { collectHistoryGroupsByResourcePath } from "./resource_page_history_groups.ts";
 import { renderKnopInventoryWithPreservedSupportArtifacts } from "./knop_support_renderers.ts";
 import {
   renderArtifactHistoryIndexPage,
@@ -471,6 +472,9 @@ function toVersionPlan(plan: WeavePlan): VersionPlan {
       ? { createdBinaryFiles: plan.createdBinaryFiles }
       : {}),
     updatedFiles,
+    ...(plan.regeneratedPagePaths === undefined
+      ? {}
+      : { regeneratedPagePaths: plan.regeneratedPagePaths }),
   };
 }
 
@@ -527,6 +531,11 @@ function applyResourcePageGenerationPolicies(
     createdPages: plan.createdPages.filter((page) =>
       generatedPagePaths.has(page.path)
     ),
+    ...(plan.regeneratedPagePaths === undefined ? {} : {
+      regeneratedPagePaths: plan.regeneratedPagePaths.filter((path) =>
+        generatedPagePaths.has(path)
+      ),
+    }),
   };
 }
 
@@ -1014,6 +1023,21 @@ function mergeFirstWeaveBatchPlans(
     }
   }
 
+  const regeneratedPagePaths: string[] = [];
+  if (meshInventoryProgression && mergedMeshInventoryTurtle) {
+    const historyIndexPath =
+      `${meshInventoryProgression.historyPath}/index.html`;
+    addUpdatedFile(updatedFiles, updatedPaths, createdPaths, {
+      path: historyIndexPath,
+      contents: renderProgressedMeshInventoryHistoryIndexPage(
+        meshBase,
+        mergedMeshInventoryTurtle,
+        meshInventoryProgression,
+      ),
+    });
+    regeneratedPagePaths.push(historyIndexPath);
+  }
+
   if (meshInventoryProgression) {
     addUpdatedFile(updatedFiles, updatedPaths, createdPaths, {
       path: "_mesh/_meta/meta.ttl",
@@ -1031,7 +1055,62 @@ function mergeFirstWeaveBatchPlans(
     ...(createdBinaryFiles.length > 0 ? { createdBinaryFiles } : {}),
     updatedFiles,
     createdPages,
+    ...(regeneratedPagePaths.length === 0 ? {} : { regeneratedPagePaths }),
   };
+}
+
+function renderProgressedMeshInventoryHistoryIndexPage(
+  meshBase: string,
+  mergedMeshInventoryTurtle: string,
+  meshInventoryProgression: MeshInventoryProgression,
+): string {
+  const historyGroups = collectHistoryGroupsByResourcePath(
+    meshBase,
+    mergedMeshInventoryTurtle,
+    "Could not parse the merged MeshInventory while rendering its history index.",
+    (message) => new WeaveInputError(message),
+  ).get(meshInventoryProgression.historyPath) ?? [];
+  const historyGroup = historyGroups.find((group) =>
+    group.path === meshInventoryProgression.historyPath
+  );
+  if (historyGroup === undefined) {
+    throw new WeaveInputError(
+      `Could not resolve ${meshInventoryProgression.historyPath} from the merged MeshInventory while rendering its history index.`,
+    );
+  }
+
+  const statePrefix = `${meshInventoryProgression.historyPath}/`;
+  const states = historyGroup.states.map((state) => {
+    if (!state.path.startsWith(statePrefix)) {
+      throw new WeaveInputError(
+        `MeshInventory historical state ${state.path} is not inside ${meshInventoryProgression.historyPath}.`,
+      );
+    }
+    const segment = state.path.slice(statePrefix.length);
+    if (segment.length === 0 || segment.includes("/")) {
+      throw new WeaveInputError(
+        `MeshInventory historical state ${state.path} does not have a direct state segment.`,
+      );
+    }
+    return {
+      segment,
+      latest: state.path === meshInventoryProgression.nextStatePath,
+    };
+  });
+  if (!states.some((state) => state.latest)) {
+    throw new WeaveInputError(
+      `Merged MeshInventory history ${meshInventoryProgression.historyPath} does not contain its planned latest state ${meshInventoryProgression.nextStatePath}.`,
+    );
+  }
+
+  return renderArtifactHistoryIndexPage(meshBase, {
+    pagePath: `${meshInventoryProgression.historyPath}/index.html`,
+    description:
+      "Resource page for the current explicit history of the MeshInventory artifact.",
+    artifactLabel: "Inventory artifact",
+    workingLocalRelativePath: "_mesh/_inventory/inventory.ttl",
+    states,
+  });
 }
 
 function resolveBatchMeshInventoryProgression(

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -3458,6 +3458,21 @@ Deno.test("planWeave batches reverse-order untargeted extracted Knops with one c
       .length,
     1,
   );
+  const meshInventoryHistoryIndexes = plan.updatedFiles.filter((file) =>
+    file.path === "_mesh/_inventory/_history001/index.html"
+  );
+  assertEquals(meshInventoryHistoryIndexes.length, 1);
+  assertEquals(plan.regeneratedPagePaths, [
+    "_mesh/_inventory/_history001/index.html",
+  ]);
+  const meshInventoryHistoryIndex = meshInventoryHistoryIndexes[0]!.contents;
+  for (const stateSegment of ["_s0001", "_s0002", "_s0003", "_s0004"]) {
+    assertStringIncludes(meshInventoryHistoryIndex, `href="./${stateSegment}"`);
+  }
+  assertStringIncludes(
+    meshInventoryHistoryIndex,
+    '<a href="./_s0004">_s0004</a> (latest)',
+  );
 
   const meshInventory =
     plan.updatedFiles.find((file) =>

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -3437,6 +3437,48 @@ Deno.test("planWeave renders the extracted bob woven slice", async () => {
   assertStringIncludes(bobPage?.contents ?? "", "<h1>bob</h1>");
 });
 
+Deno.test("planWeave batches reverse-order untargeted extracted Knops with one canonical MeshInventory progression", async () => {
+  const plan = planWeave(await createExtractedBobAndCarolBatchInput());
+
+  assertEquals(plan.wovenDesignatorPaths, ["bob", "carol"]);
+  assertEquals(
+    plan.createdFiles.filter((file) =>
+      file.path === "_mesh/_inventory/_history001/_s0004/ttl/inventory.ttl"
+    ).length,
+    1,
+  );
+  assertEquals(
+    plan.updatedFiles.filter((file) =>
+      file.path === "_mesh/_inventory/inventory.ttl"
+    ).length,
+    1,
+  );
+  assertEquals(
+    plan.updatedFiles.filter((file) => file.path === "_mesh/_meta/meta.ttl")
+      .length,
+    1,
+  );
+
+  const meshInventory =
+    plan.updatedFiles.find((file) =>
+      file.path === "_mesh/_inventory/inventory.ttl"
+    )?.contents ?? "";
+  const bobIndex = meshInventory.indexOf("<bob>\n");
+  const carolIndex = meshInventory.indexOf("<carol>\n");
+  assert(bobIndex >= 0, meshInventory);
+  assert(carolIndex > bobIndex, meshInventory);
+  for (const designatorPath of ["bob", "carol"]) {
+    assertStringIncludes(
+      meshInventory,
+      `<${designatorPath}>\n  sflo:hasResourcePage <${designatorPath}/index.html> .`,
+    );
+    assertStringIncludes(
+      meshInventory,
+      `<${designatorPath}/_knop> a sflo:Knop ;\n  sflo:hasWorkingKnopInventoryFile <${designatorPath}/_knop/_inventory/inventory.ttl> ;\n  sflo:hasResourcePage <${designatorPath}/_knop/index.html> .`,
+    );
+  }
+});
+
 Deno.test("planWeave renders an extracted term from a nested source without a root Knop", async () => {
   const input = await createExtractedBobWeaveInput();
   input.currentMeshInventoryTurtle = input.currentMeshInventoryTurtle
@@ -4479,6 +4521,47 @@ async function createExtractedBobWeaveInput(): Promise<PlanWeaveInput> {
         },
       },
     }],
+  };
+}
+
+async function createExtractedBobAndCarolBatchInput(): Promise<PlanWeaveInput> {
+  const input = await createExtractedBobWeaveInput();
+  const bobCandidate = input.weaveableKnops[0]!;
+  const source = bobCandidate.referenceTargetSourcePayloadArtifact!;
+  const carolExtractPlan = planExtract({
+    meshBase: input.meshBase,
+    currentMeshInventoryTurtle: input.currentMeshInventoryTurtle,
+    designatorPath: "carol",
+    sourceDesignatorPath: source.designatorPath,
+    sourceStatePath: source.latestHistoricalStatePath,
+    sourceEvidence: source.sourceEvidence,
+    sourceWorkingLocalRelativePath: source.workingLocalRelativePath,
+  });
+  const carolCreatedFileByPath = new Map(
+    carolExtractPlan.createdFiles.map((file) => [file.path, file.contents]),
+  );
+
+  return {
+    ...input,
+    request: {},
+    currentMeshInventoryTurtle: carolExtractPlan.updatedFiles[0]!.contents,
+    weaveableKnops: [{
+      designatorPath: "carol",
+      currentKnopMetadataTurtle: carolCreatedFileByPath.get(
+        "carol/_knop/_meta/meta.ttl",
+      )!,
+      currentKnopInventoryTurtle: carolCreatedFileByPath.get(
+        "carol/_knop/_inventory/inventory.ttl",
+      )!,
+      referenceTargetSourcePayloadArtifact: {
+        ...source,
+        sourceRegistryWorkingLocalRelativePath:
+          "carol/_knop/_sources/sources.ttl",
+        currentSourceRegistryTurtle: carolCreatedFileByPath.get(
+          "carol/_knop/_sources/sources.ttl",
+        )!,
+      },
+    }, bobCandidate],
   };
 }
 

--- a/src/runtime/weave/memory_stats.ts
+++ b/src/runtime/weave/memory_stats.ts
@@ -88,6 +88,7 @@ class EnabledRuntimeMemoryStats implements RuntimeMemoryStats {
     candidates: readonly WeaveableKnopCandidate[],
     overlay: TextFileOverlay,
   ): void {
+    this.#sampleRss();
     const sampled = overlay.retainedCandidateLiveSetMemoryStats(
       workspaceRoot,
       candidates,
@@ -107,6 +108,10 @@ class EnabledRuntimeMemoryStats implements RuntimeMemoryStats {
 
   samplePlanningLoopIteration(): void {
     this.#planningLoopIterations += 1;
+    this.#sampleRss();
+  }
+
+  #sampleRss(): void {
     if (typeof Deno.memoryUsage === "function") {
       this.#maxRssBytes = Math.max(
         this.#maxRssBytes,
@@ -120,6 +125,7 @@ class EnabledRuntimeMemoryStats implements RuntimeMemoryStats {
     updatedFiles: ReadonlyMap<string, PlannedFile>,
     overlay: TextFileOverlay,
   ): void {
+    this.#sampleRss();
     const encoder = new TextEncoder();
     const createdStats = emptyCreatedFileStats();
     for (const file of createdFiles) {

--- a/src/runtime/weave/page_generation.ts
+++ b/src/runtime/weave/page_generation.ts
@@ -45,6 +45,15 @@ export interface GeneratePreparedPagesResult {
   skippedTimestampOnlyPaths: readonly string[];
 }
 
+export interface RegeneratePreparedPagePathsOptions {
+  meshRoot: string;
+  localPathPolicy: OperationalLocalPathPolicy;
+  pagePaths: readonly string[];
+  historyTrackingPolicyOverride?: HistoryTrackingPolicy;
+  timing?: RuntimeTiming;
+  phasePrefix?: string;
+}
+
 export async function generatePreparedPages(
   options: GeneratePreparedPagesOptions,
 ): Promise<GeneratePreparedPagesResult> {
@@ -132,6 +141,102 @@ export async function generatePreparedPages(
     );
   }
   return result;
+}
+
+export async function regeneratePreparedPagePaths(
+  options: RegeneratePreparedPagePathsOptions,
+): Promise<GeneratePreparedPagesResult> {
+  if (options.pagePaths.length === 0) {
+    throw new WeaveInputError(
+      "At least one generated ResourcePage path is required for regeneration.",
+    );
+  }
+  const phase = (name: string) =>
+    options.phasePrefix ? `${options.phasePrefix}.${name}` : name;
+  const meshState = await timeOptional(
+    options.timing,
+    phase("loadMeshState"),
+    () => loadMeshState(options.meshRoot),
+  );
+  const effectiveConfigProvider = createEffectiveConfigProviderForExecution({
+    meshRoot: options.meshRoot,
+    meshState,
+    localPathPolicy: options.localPathPolicy,
+    historyTrackingPolicyOverride: options.historyTrackingPolicyOverride,
+    includeSemanticFlowMetadata: false,
+    timing: options.timing,
+    phasePrefix: phase("effectiveConfig"),
+  });
+  const pageModels = await timeOptional(
+    options.timing,
+    phase("collectResourcePageModels"),
+    () =>
+      collectResourcePageModels({
+        workspaceRoot: options.meshRoot,
+        localPathPolicy: options.localPathPolicy,
+        meshState,
+        selectedDesignatorPaths: [],
+        includeAllMeshPages: false,
+        hasExplicitGenerateTargets: false,
+        effectiveConfigProvider,
+        timing: options.timing,
+        phasePrefix: phase("collectResourcePageModels"),
+      }),
+  );
+  const requestedPaths = new Set(options.pagePaths);
+  const selectedPageModels = pageModels.filter((page) =>
+    requestedPaths.has(page.path)
+  );
+  const selectedPaths = new Set(selectedPageModels.map((page) => page.path));
+  const missingPaths = options.pagePaths.filter((path) =>
+    !selectedPaths.has(path)
+  );
+  if (missingPaths.length > 0) {
+    throw new WeaveInputError(
+      `Could not regenerate planned ResourcePage paths from the settled inventory: ${
+        missingPaths.join(", ")
+      }.`,
+    );
+  }
+
+  const meshFaviconPath = await resolveMeshFaviconPath(options.meshRoot);
+  const pageFiles = await timeOptional(
+    options.timing,
+    phase("renderResourcePages"),
+    () =>
+      renderResourcePages(meshState.meshBase, selectedPageModels, {
+        generatedAt: resolveGeneratedAt(),
+        includeSemanticFlowMetadata: false,
+        meshFaviconPath,
+        resourcePagePresentationForPage: (page) =>
+          resourcePagePresentationForGeneratedPage(
+            effectiveConfigProvider,
+            page,
+          ),
+      }),
+  );
+  const writeResult = await timeOptional(
+    options.timing,
+    phase("writePages"),
+    () =>
+      writeGeneratedPagesUpsert(options.meshRoot, pageFiles, {
+        updateTimestampOnlyPages: false,
+      }),
+  );
+
+  return {
+    meshBase: meshState.meshBase,
+    generatedDesignatorPaths: [],
+    createdPaths: writeResult.createdPaths.map((path) =>
+      toWorkspaceRelativePath(options.localPathPolicy, path)
+    ),
+    updatedPaths: writeResult.updatedPaths.map((path) =>
+      toWorkspaceRelativePath(options.localPathPolicy, path)
+    ),
+    skippedTimestampOnlyPaths: writeResult.skippedTimestampOnlyPaths.map(
+      (path) => toWorkspaceRelativePath(options.localPathPolicy, path),
+    ),
+  };
 }
 
 export async function collectGeneratedPageFiles(

--- a/src/runtime/weave/version_execution.ts
+++ b/src/runtime/weave/version_execution.ts
@@ -381,7 +381,6 @@ export async function prepareVersionExecution(
         ),
     )
     : [];
-  timing?.setField("payloadBatchCandidates", payloadBatchCandidates.length);
   if (inputSnapshot !== undefined) {
     await timeOptional(
       timing,
@@ -410,18 +409,21 @@ export async function prepareVersionExecution(
   });
   const meshEffectiveConfig = await effectiveConfigProvider
     .configForMeshScope();
-  const untargetedFirstPayloadBatch = targets.length === 0 &&
-    isUntargetedFirstPayloadBatch(
+  const untargetedFirstBatchSlice = targets.length === 0 &&
+      !overwriteExistingState
+    ? detectUntargetedFirstBatchSlice(
       meshState.meshBase,
       initialWeaveableKnops,
-    );
-  const batchCandidates = untargetedFirstPayloadBatch
+    )
+    : undefined;
+  const batchCandidates = untargetedFirstBatchSlice !== undefined
     ? initialWeaveableKnops
     : payloadBatchCandidates;
+  timing?.setField("payloadBatchCandidates", batchCandidates.length);
 
   if (
     batchCandidates.length > 0 &&
-    (untargetedFirstPayloadBatch ||
+    (untargetedFirstBatchSlice !== undefined ||
       isExplicitPayloadBatch(
         meshState.meshBase,
         batchCandidates,
@@ -442,6 +444,9 @@ export async function prepareVersionExecution(
             effectiveConfigProvider,
             overwriteExistingState,
             timing,
+            untargetedFirstBatchSlice === "firstExtractedKnopWeave"
+              ? "candidateArtifacts"
+              : "allArtifacts",
           );
         } catch (error) {
           throw ensureWeaveInputErrorFindingCode(
@@ -466,6 +471,20 @@ export async function prepareVersionExecution(
           ),
       });
     }
+    timing?.setField("cachedReadFiles", overlay.readCount);
+    timing?.setField("readCacheHits", overlay.cacheHitCount);
+    timing?.setField("stagedReadHits", overlay.stagedHitCount);
+    timing?.setField("candidateCacheHits", overlay.candidateCacheHitCount);
+    timing?.setField("candidateCacheStores", overlay.candidateCacheStoreCount);
+    timing?.setField(
+      "candidateCacheInvalidations",
+      overlay.candidateCacheInvalidationCount,
+    );
+    memoryStats?.captureVersionExecutionRetainedState(
+      batchPlan.createdFiles,
+      new Map(batchPlan.updatedFiles.map((file) => [file.path, file])),
+      overlay,
+    );
     return {
       meshState,
       plan: batchPlan,
@@ -910,18 +929,33 @@ function isExplicitPayloadBatch(
   });
 }
 
-function isUntargetedFirstPayloadBatch(
+function detectUntargetedFirstBatchSlice(
   meshBase: string,
   candidates: readonly WeaveableKnopCandidate[],
-): boolean {
-  return candidates.length > 1 &&
-    candidates.every((candidate) =>
+): "firstPayloadWeave" | "firstExtractedKnopWeave" | undefined {
+  if (candidates.length <= 1) {
+    return undefined;
+  }
+  const firstSlice = detectPendingWeaveSlice(
+    meshBase,
+    candidates[0]!.designatorPath,
+    candidates[0]!.currentKnopInventoryTurtle,
+  );
+  if (
+    firstSlice !== "firstPayloadWeave" &&
+    firstSlice !== "firstExtractedKnopWeave"
+  ) {
+    return undefined;
+  }
+  return candidates.every((candidate) =>
       detectPendingWeaveSlice(
         meshBase,
         candidate.designatorPath,
         candidate.currentKnopInventoryTurtle,
-      ) === "firstPayloadWeave"
-    );
+      ) === firstSlice
+    )
+    ? firstSlice
+    : undefined;
 }
 
 async function planExplicitPayloadBatchVersion(
@@ -935,6 +969,8 @@ async function planExplicitPayloadBatchVersion(
   effectiveConfigProvider: EffectiveConfigProvider,
   overwriteExistingState: boolean,
   timing?: RuntimeTiming,
+  resourcePagePolicyProbeMode: "allArtifacts" | "candidateArtifacts" =
+    "allArtifacts",
 ): Promise<VersionPlan> {
   const orderedCandidates = [...candidates].sort((left, right) =>
     left.designatorPath.localeCompare(right.designatorPath)
@@ -944,6 +980,7 @@ async function planExplicitPayloadBatchVersion(
     orderedCandidates,
     meshEffectiveConfig,
     effectiveConfigProvider,
+    resourcePagePolicyProbeMode,
   );
   return timeOptionalSync(
     timing,
@@ -974,6 +1011,8 @@ async function resolvePayloadBatchPolicies(
   orderedCandidates: readonly WeaveableKnopCandidate[],
   meshEffectiveConfig: EffectiveConfig,
   effectiveConfigProvider: EffectiveConfigProvider,
+  resourcePagePolicyProbeMode: "allArtifacts" | "candidateArtifacts" =
+    "allArtifacts",
 ): Promise<{
   supportHistoryPolicies: ReturnType<
     typeof supportHistoryPoliciesFromScopedEffectiveConfigs
@@ -1027,12 +1066,16 @@ async function resolvePayloadBatchPolicies(
     const comparisonKey = JSON.stringify({
       supportHistoryPolicies,
       namingPolicies,
-      resourcePageGenerationConfig: snapshotResourcePageGenerationConfig(
-        meshBase,
-        resourcePageGenerationConfig,
-        orderedCandidates,
-      ),
       resourcePageGenerationPolicies,
+      ...(resourcePagePolicyProbeMode === "allArtifacts"
+        ? {
+          resourcePageGenerationConfig: snapshotResourcePageGenerationConfig(
+            meshBase,
+            resourcePageGenerationConfig,
+            orderedCandidates,
+          ),
+        }
+        : {}),
     });
 
     if (first === undefined) {
@@ -1046,7 +1089,22 @@ async function resolvePayloadBatchPolicies(
       };
       continue;
     }
-    if (comparisonKey !== first.comparisonKey) {
+    const candidateArtifactPoliciesMatch =
+      resourcePagePolicyProbeMode === "allArtifacts" ||
+      JSON.stringify(snapshotResourcePageGenerationConfig(
+          meshBase,
+          resourcePageGenerationConfig,
+          [candidate],
+        )) ===
+        JSON.stringify(snapshotResourcePageGenerationConfig(
+          meshBase,
+          first.resourcePageGenerationConfig,
+          [candidate],
+        ));
+    if (
+      comparisonKey !== first.comparisonKey ||
+      !candidateArtifactPoliciesMatch
+    ) {
       throw new WeaveInputError(
         `Multi-target payload weave requires consistent target-scoped planning policies; ${candidate.designatorPath} differs from ${first.designatorPath}.`,
       );

--- a/src/runtime/weave/weave.ts
+++ b/src/runtime/weave/weave.ts
@@ -38,7 +38,10 @@ import {
   normalizeVersionRequest,
   normalizeWeaveRequest,
 } from "./request_normalization.ts";
-import { generatePreparedPages } from "./page_generation.ts";
+import {
+  generatePreparedPages,
+  regeneratePreparedPagePaths,
+} from "./page_generation.ts";
 import {
   type InputSnapshotVerificationHooks,
   prepareVersionExecution,
@@ -367,7 +370,7 @@ export async function executeVersion(
       timing,
       options.inputSnapshotVerification,
     );
-    const result = await writePreparedVersion(
+    const versionResult = await writePreparedVersion(
       meshRoot,
       localPathPolicy,
       prepared,
@@ -377,6 +380,28 @@ export async function executeVersion(
         phasePrefix: "write",
       },
     );
+    const regeneratedPages = prepared.plan.regeneratedPagePaths === undefined ||
+        prepared.plan.regeneratedPagePaths.length === 0
+      ? undefined
+      : await regeneratePreparedPagePaths({
+        meshRoot,
+        localPathPolicy,
+        pagePaths: prepared.plan.regeneratedPagePaths,
+        historyTrackingPolicyOverride: options.historyTrackingPolicyOverride,
+        timing,
+        phasePrefix: "write.regeneratePages",
+      });
+    const result: VersionResult = {
+      ...versionResult,
+      createdPaths: [
+        ...versionResult.createdPaths,
+        ...(regeneratedPages?.createdPaths ?? []),
+      ],
+      updatedPaths: [
+        ...versionResult.updatedPaths,
+        ...(regeneratedPages?.updatedPaths ?? []),
+      ],
+    };
     timing.setField(
       "versionedDesignatorPaths",
       result.versionedDesignatorPaths.length,

--- a/tests/scripts/pending_heavy_mesh_test.ts
+++ b/tests/scripts/pending_heavy_mesh_test.ts
@@ -12,7 +12,7 @@ import {
 import { normalizeVersionRequest } from "../../src/runtime/weave/request_normalization.ts";
 import {
   executeGenerate,
-  executeWeave,
+  executeVersion,
 } from "../../src/runtime/weave/weave.ts";
 import type { RuntimeMemoryStatsReport } from "../../src/runtime/weave/memory_stats.ts";
 import { loadOperationalLocalPathPolicy } from "../../src/runtime/operational/local_path_policy.ts";
@@ -102,11 +102,14 @@ Deno.test("untargeted extracted candidates use one instrumented coherent batch a
     ).length,
     1,
   );
+  assertEquals(prepared.plan.regeneratedPagePaths, [
+    "_mesh/_inventory/_history001/index.html",
+  ]);
 
   const fixedNow = () => new Date("2026-08-06T12:00:00.000Z");
-  const woven = await executeWeave({ meshRoot, now: fixedNow });
+  const woven = await executeVersion({ meshRoot });
   assertEquals(
-    woven.wovenDesignatorPaths,
+    woven.versionedDesignatorPaths,
     generated.extractedDesignatorPaths,
   );
   assertEquals(
@@ -153,16 +156,100 @@ Deno.test("untargeted extracted candidates use one instrumented coherent batch a
     );
   }
 
-  const nonHtmlDigestsBeforeGenerate = await digestNonHtmlWorkspaceFiles(
+  const meshInventoryHistoryIndexPath =
+    "_mesh/_inventory/_history001/index.html";
+  const historyIndexDigestAfterVersion = await sha256(
+    await Deno.readFile(join(meshRoot, meshInventoryHistoryIndexPath)),
+  );
+  const generatedAfterVersion = await executeGenerate({
+    meshRoot,
+    now: fixedNow,
+  });
+  assertEquals(
+    generatedAfterVersion.updatedPaths.filter((path) =>
+      path === meshInventoryHistoryIndexPath
+    ),
+    [],
+  );
+  assertEquals(
+    await sha256(
+      await Deno.readFile(join(meshRoot, meshInventoryHistoryIndexPath)),
+    ),
+    historyIndexDigestAfterVersion,
+  );
+
+  const workspaceDigestsBeforeRegenerate = await digestWorkspaceFiles(
     meshRoot,
   );
   const generatedAgain = await executeGenerate({ meshRoot, now: fixedNow });
   assertEquals(generatedAgain.createdPaths, []);
   assertEquals(generatedAgain.updatedPaths, []);
   assertEquals(
-    await digestNonHtmlWorkspaceFiles(meshRoot),
-    nonHtmlDigestsBeforeGenerate,
+    await digestWorkspaceFiles(meshRoot),
+    workspaceDigestsBeforeRegenerate,
   );
+});
+
+Deno.test("untargeted multi-candidate extracted batch restructures a current-only MeshInventory once", async () => {
+  const meshRoot = await createTestTmpDir(
+    "weave-pending-heavy-current-only-extracted-batch-",
+  );
+  const generated = await generatePendingHeavyMesh({
+    outputPath: meshRoot,
+    count: 3,
+    meshInventoryHistoryPolicy: "current-only",
+    sourceDesignatorPath: "catalog/source",
+  });
+  const localPathPolicy = await loadOperationalLocalPathPolicy(meshRoot);
+  const timing = new RecordingRuntimeTiming();
+  const prepared = await prepareVersionExecution(
+    meshRoot,
+    [],
+    localPathPolicy,
+    false,
+    undefined,
+    undefined,
+    timing,
+  );
+
+  assertEquals(
+    timing.fields.get("payloadBatchCandidates"),
+    generated.count,
+  );
+  assertEquals(timing.phaseCount("prepare.planPayloadBatch"), 1);
+  assertEquals(timing.phaseCount("prepare.loop.planVersion"), 0);
+  assertEquals(prepared.plan.versionedDesignatorPaths, [
+    "term-000001",
+    "term-000002",
+    "term-000003",
+  ]);
+  assertEquals(prepared.plan.createdFiles, []);
+  assertEquals(prepared.plan.regeneratedPagePaths, undefined);
+
+  const meshInventoryUpdates = prepared.plan.updatedFiles.filter((file) =>
+    file.path === "_mesh/_inventory/inventory.ttl"
+  );
+  assertEquals(meshInventoryUpdates.length, 1);
+  const meshInventory = meshInventoryUpdates[0]!.contents;
+  assert(
+    meshInventory.includes(
+      `<_mesh/_inventory> a sflo:MeshInventory, sflo:DigitalArtifact, sflo:RdfDocument ;
+  sflo:hasWorkingLocatedFile <_mesh/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <_mesh/_inventory/index.html> .`,
+    ),
+    meshInventory,
+  );
+  assertEquals(meshInventory.includes("_mesh/_inventory/_history"), false);
+  for (const designatorPath of generated.extractedDesignatorPaths) {
+    assert(
+      meshInventory.includes(
+        `<${designatorPath}/_knop> a sflo:Knop ;
+  sflo:hasWorkingKnopInventoryFile <${designatorPath}/_knop/_inventory/inventory.ttl> ;
+  sflo:hasResourcePage <${designatorPath}/_knop/index.html> .`,
+      ),
+      `Missing restructured current-only Knop block for ${designatorPath}.`,
+    );
+  }
 });
 
 Deno.test("mixed and recursive extracted candidate sets retain sequential planning", async () => {
@@ -617,15 +704,12 @@ async function digestWorkspacePaths(
   return digests;
 }
 
-async function digestNonHtmlWorkspaceFiles(
+async function digestWorkspaceFiles(
   workspaceRoot: string,
 ): Promise<Map<string, string>> {
   const digests = new Map<string, string>();
   for (const absolutePath of await listWorkspaceFiles(workspaceRoot)) {
     const path = relative(workspaceRoot, absolutePath).replaceAll("\\", "/");
-    if (path.endsWith(".html")) {
-      continue;
-    }
     digests.set(path, await sha256(await Deno.readFile(absolutePath)));
   }
   return digests;

--- a/tests/scripts/pending_heavy_mesh_test.ts
+++ b/tests/scripts/pending_heavy_mesh_test.ts
@@ -5,10 +5,15 @@ import {
   assertRejects,
   assertStrictEquals,
 } from "@std/assert";
-import { fromFileUrl, join } from "@std/path";
+import { fromFileUrl, join, relative } from "@std/path";
 import {
   generatePendingHeavyMesh,
 } from "../../scripts/generate-pending-heavy-mesh.ts";
+import { normalizeVersionRequest } from "../../src/runtime/weave/request_normalization.ts";
+import {
+  executeGenerate,
+  executeWeave,
+} from "../../src/runtime/weave/weave.ts";
 import type { RuntimeMemoryStatsReport } from "../../src/runtime/weave/memory_stats.ts";
 import { loadOperationalLocalPathPolicy } from "../../src/runtime/operational/local_path_policy.ts";
 import { loadWeaveableKnopCandidates } from "../../src/runtime/weave/candidate_loader.ts";
@@ -17,12 +22,207 @@ import {
   applyPlannedFilesToOverlay,
   TextFileOverlay,
 } from "../../src/runtime/weave/planning_context.ts";
+import { prepareVersionExecution } from "../../src/runtime/weave/version_execution.ts";
+import type {
+  RuntimeTiming,
+  RuntimeTimingField,
+} from "../../src/runtime/timing.ts";
+import {
+  hasNamedNodeFact,
+  parseWeaveShapeQuads,
+} from "../../src/core/weave/rdf_helpers.ts";
+import { SFLO_NAMESPACE } from "../../src/core/rdf/namespaces.ts";
 import { createTestTmpDir } from "../support/test_tmp.ts";
 
 const repoRoot = fromFileUrl(new URL("../../", import.meta.url));
 const cliEntrypoint = join(repoRoot, "src/main.ts");
+const sfloHasResourcePageIri = `${SFLO_NAMESPACE}hasResourcePage`;
 
-Deno.test("pending-heavy generator enters the instrumented recursive validation loop", async () => {
+Deno.test("untargeted extracted candidates use one instrumented coherent batch and regenerate byte-stably", async () => {
+  const meshRoot = await createTestTmpDir(
+    "weave-pending-heavy-extracted-batch-",
+  );
+  const generated = await generatePendingHeavyMesh({
+    outputPath: meshRoot,
+    count: 3,
+    meshInventoryHistoryPolicy: "versioned",
+    sourceDesignatorPath: "catalog/source",
+  });
+  const meshState = await loadMeshState(meshRoot);
+  const localPathPolicy = await loadOperationalLocalPathPolicy(meshRoot);
+  const pendingBefore = await loadWeaveableKnopCandidates(
+    meshRoot,
+    localPathPolicy,
+    meshState.meshBase,
+    meshState.currentMeshInventoryTurtle,
+    [],
+    new Map(),
+    new TextFileOverlay(),
+  );
+  const sourceArtifact = pendingBefore[0]!
+    .referenceTargetSourcePayloadArtifact!;
+  const protectedSourcePaths = [
+    sourceArtifact.workingLocalRelativePath,
+    sourceArtifact.latestHistoricalSnapshotPath!,
+  ];
+  const sourceDigestsBefore = await digestWorkspacePaths(
+    meshRoot,
+    protectedSourcePaths,
+  );
+
+  const timing = new RecordingRuntimeTiming();
+  const prepared = await prepareVersionExecution(
+    meshRoot,
+    [],
+    localPathPolicy,
+    false,
+    undefined,
+    undefined,
+    timing,
+  );
+
+  assertEquals(
+    timing.fields.get("payloadBatchCandidates"),
+    generated.count,
+  );
+  assertEquals(
+    prepared.plan.versionedDesignatorPaths,
+    generated.extractedDesignatorPaths,
+  );
+  assertEquals(
+    prepared.plan.createdFiles.filter((file) =>
+      /^_mesh\/_inventory\/_history[^/]+\/_s[^/]+\/ttl\/inventory\.ttl$/
+        .test(file.path)
+    ).length,
+    1,
+  );
+  assertEquals(
+    prepared.plan.updatedFiles.filter((file) =>
+      file.path === "_mesh/_inventory/inventory.ttl"
+    ).length,
+    1,
+  );
+
+  const fixedNow = () => new Date("2026-08-06T12:00:00.000Z");
+  const woven = await executeWeave({ meshRoot, now: fixedNow });
+  assertEquals(
+    woven.wovenDesignatorPaths,
+    generated.extractedDesignatorPaths,
+  );
+  assertEquals(
+    await digestWorkspacePaths(meshRoot, protectedSourcePaths),
+    sourceDigestsBefore,
+  );
+
+  const wovenMeshState = await loadMeshState(meshRoot);
+  const pendingAfter = await loadWeaveableKnopCandidates(
+    meshRoot,
+    localPathPolicy,
+    wovenMeshState.meshBase,
+    wovenMeshState.currentMeshInventoryTurtle,
+    [],
+    new Map(),
+    new TextFileOverlay(),
+  );
+  assertEquals(pendingAfter, []);
+  const meshInventoryQuads = parseWeaveShapeQuads(
+    wovenMeshState.meshBase,
+    wovenMeshState.currentMeshInventoryTurtle,
+    "Could not parse woven pending-heavy MeshInventory.",
+  );
+  for (const designatorPath of generated.extractedDesignatorPaths) {
+    assert(
+      hasNamedNodeFact(
+        meshInventoryQuads,
+        wovenMeshState.meshBase,
+        designatorPath,
+        sfloHasResourcePageIri,
+        `${designatorPath}/index.html`,
+      ),
+      `Missing canonical ResourcePage claim for ${designatorPath}.`,
+    );
+    assert(
+      hasNamedNodeFact(
+        meshInventoryQuads,
+        wovenMeshState.meshBase,
+        `${designatorPath}/_knop`,
+        sfloHasResourcePageIri,
+        `${designatorPath}/_knop/index.html`,
+      ),
+      `Missing canonical Knop ResourcePage claim for ${designatorPath}.`,
+    );
+  }
+
+  const nonHtmlDigestsBeforeGenerate = await digestNonHtmlWorkspaceFiles(
+    meshRoot,
+  );
+  const generatedAgain = await executeGenerate({ meshRoot, now: fixedNow });
+  assertEquals(generatedAgain.createdPaths, []);
+  assertEquals(generatedAgain.updatedPaths, []);
+  assertEquals(
+    await digestNonHtmlWorkspaceFiles(meshRoot),
+    nonHtmlDigestsBeforeGenerate,
+  );
+});
+
+Deno.test("mixed and recursive extracted candidate sets retain sequential planning", async () => {
+  const mixedRoot = await createTestTmpDir(
+    "weave-pending-heavy-mixed-sequential-",
+  );
+  await generatePendingHeavyMesh({
+    outputPath: mixedRoot,
+    count: 2,
+    meshInventoryHistoryPolicy: "current-only",
+    sourceDesignatorPath: "catalog/source",
+  });
+  await Deno.writeTextFile(
+    join(mixedRoot, "source.ttl"),
+    `${await Deno.readTextFile(
+      join(mixedRoot, "source.ttl"),
+    )}\n<catalog/source> <https://schema.org/version> "2" .\n`,
+  );
+  const mixedTiming = new RecordingRuntimeTiming();
+  const mixedPolicy = await loadOperationalLocalPathPolicy(mixedRoot);
+  await prepareVersionExecution(
+    mixedRoot,
+    [],
+    mixedPolicy,
+    false,
+    undefined,
+    undefined,
+    mixedTiming,
+  );
+  assertEquals(mixedTiming.phaseCount("prepare.planPayloadBatch"), 0);
+  assertEquals(mixedTiming.phaseCount("prepare.loop.planVersion"), 3);
+
+  const recursiveRoot = await createTestTmpDir(
+    "weave-pending-heavy-recursive-sequential-",
+  );
+  await generatePendingHeavyMesh({
+    outputPath: recursiveRoot,
+    count: 2,
+    meshInventoryHistoryPolicy: "current-only",
+    sourceDesignatorPath: "catalog/source",
+  });
+  const recursiveTiming = new RecordingRuntimeTiming();
+  const recursivePolicy = await loadOperationalLocalPathPolicy(recursiveRoot);
+  const recursiveTargets = normalizeVersionRequest({
+    targets: [{ designatorPath: "", recursive: true }],
+  }).targets;
+  await prepareVersionExecution(
+    recursiveRoot,
+    recursiveTargets,
+    recursivePolicy,
+    false,
+    undefined,
+    undefined,
+    recursiveTiming,
+  );
+  assertEquals(recursiveTiming.phaseCount("prepare.planPayloadBatch"), 0);
+  assertEquals(recursiveTiming.phaseCount("prepare.loop.planVersion"), 2);
+});
+
+Deno.test("pending-heavy generator enters the instrumented coherent batch path", async () => {
   const currentOnlyRoot = await createTestTmpDir(
     "weave-pending-heavy-current-only-",
   );
@@ -36,23 +236,20 @@ Deno.test("pending-heavy generator enters the instrumented recursive validation 
   const enabled = await runValidate(currentOnlyRoot, "1");
   assert(enabled.output.success, enabled.stderr);
   const currentReport = parseMemoryStats(enabled.stderr);
-  assertEquals(currentReport.planningLoopIterations, 3);
+  assertEquals(currentReport.planningLoopIterations, 0);
   assertEquals(currentReport.createdFiles.count, 0);
   assertEquals(currentReport.createdFiles.bytes, 0);
   assertGreater(currentReport.updatedFileByPath.count, 0);
   assertGreater(currentReport.updatedFileByPath.bytes, 0);
-  assertGreater(currentReport.overlayStaged.entries, 0);
-  assertGreater(currentReport.overlayStaged.bytes, 0);
+  assertEquals(currentReport.overlayStaged.entries, 0);
+  assertEquals(currentReport.overlayStaged.bytes, 0);
   assertGreater(currentReport.readCache.entries, 0);
   assertGreater(currentReport.readCache.bytes, 0);
   assertGreater(currentReport.readCache.hits, 0);
   assertGreater(currentReport.candidateCache.entries, 0);
-  assertEquals(
-    currentReport.candidateCache.approximateRetainedBytes,
-    0,
-  );
+  assertGreater(currentReport.candidateCache.approximateRetainedBytes, 0);
   assertGreater(currentReport.candidateCache.stores, 0);
-  assertGreater(currentReport.candidateCache.invalidations, 0);
+  assertEquals(currentReport.candidateCache.invalidations, 0);
   assertEquals(currentReport.candidateLiveSet.entries, 3);
   assertEquals(currentReport.candidateLiveSet.sourceTextReferences, 6);
   assertEquals(
@@ -76,7 +273,7 @@ Deno.test("pending-heavy generator enters the instrumented recursive validation 
   const gcEnabled = await runValidate(currentOnlyRoot, "1", true);
   assert(gcEnabled.output.success, gcEnabled.stderr);
   const gcReport = parseMemoryStats(gcEnabled.stderr);
-  assertEquals(gcReport.planningLoopIterations, 3);
+  assertEquals(gcReport.planningLoopIterations, 0);
   assertGreater(gcReport.v8Heap.usedHeapSize, 0);
   assertGreater(gcReport.v8Heap.postGcUsedHeapSize!, 0);
 
@@ -278,11 +475,11 @@ Deno.test("pending-heavy generator materializes mesh-inventory history when requ
   const enabled = await runValidate(versionedRoot, "1");
   assert(enabled.output.success, enabled.stderr);
   const report = parseMemoryStats(enabled.stderr);
-  assertEquals(report.planningLoopIterations, 2);
-  assertGreater(
+  assertEquals(report.planningLoopIterations, 0);
+  assertEquals(
     report.createdFiles.byPathClassification
       .meshInventoryHistorySnapshots.count,
-    0,
+    1,
   );
   assertGreater(
     report.createdFiles.byPathClassification
@@ -317,7 +514,7 @@ Deno.test("pending-heavy generator adds deterministic per-term content", async (
 
   const enabled = await runValidate(meshRoot, "1");
   assert(enabled.output.success, enabled.stderr);
-  assertEquals(parseMemoryStats(enabled.stderr).planningLoopIterations, 2);
+  assertEquals(parseMemoryStats(enabled.stderr).planningLoopIterations, 0);
 });
 
 async function runValidate(
@@ -373,4 +570,89 @@ function parseMemoryStats(stderr: string): RuntimeMemoryStatsReport {
   );
   assert(line !== undefined, stderr);
   return JSON.parse(line.slice(prefix.length)) as RuntimeMemoryStatsReport;
+}
+
+class RecordingRuntimeTiming implements RuntimeTiming {
+  readonly enabled = true;
+  readonly fields = new Map<string, RuntimeTimingField>();
+  readonly #phaseCounts = new Map<string, number>();
+
+  setField(key: string, value: RuntimeTimingField): void {
+    this.fields.set(key, value);
+  }
+
+  async time<T>(phase: string, operation: () => Promise<T>): Promise<T> {
+    this.#recordPhase(phase);
+    return await operation();
+  }
+
+  timeSync<T>(phase: string, operation: () => T): T {
+    this.#recordPhase(phase);
+    return operation();
+  }
+
+  finish(_fields?: Record<string, RuntimeTimingField>): void {
+  }
+
+  phaseCount(phase: string): number {
+    return this.#phaseCounts.get(phase) ?? 0;
+  }
+
+  #recordPhase(phase: string): void {
+    this.#phaseCounts.set(phase, this.phaseCount(phase) + 1);
+  }
+}
+
+async function digestWorkspacePaths(
+  workspaceRoot: string,
+  paths: readonly string[],
+): Promise<Map<string, string>> {
+  const digests = new Map<string, string>();
+  for (const path of paths) {
+    digests.set(
+      path,
+      await sha256(await Deno.readFile(join(workspaceRoot, path))),
+    );
+  }
+  return digests;
+}
+
+async function digestNonHtmlWorkspaceFiles(
+  workspaceRoot: string,
+): Promise<Map<string, string>> {
+  const digests = new Map<string, string>();
+  for (const absolutePath of await listWorkspaceFiles(workspaceRoot)) {
+    const path = relative(workspaceRoot, absolutePath).replaceAll("\\", "/");
+    if (path.endsWith(".html")) {
+      continue;
+    }
+    digests.set(path, await sha256(await Deno.readFile(absolutePath)));
+  }
+  return digests;
+}
+
+async function sha256(bytes: Uint8Array): Promise<string> {
+  const digestInput = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(digestInput).set(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", digestInput);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function listWorkspaceFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  const directories = [root];
+  while (directories.length > 0) {
+    const directory = directories.pop()!;
+    for await (const entry of Deno.readDir(directory)) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory) {
+        directories.push(path);
+      } else if (entry.isFile) {
+        files.push(path);
+      }
+    }
+  }
+  return files.sort();
 }


### PR DESCRIPTION
Queue item 1. Extracted-term candidates now enter the batch path that `v0.7.0` built for `firstPayloadWeave`.

**Note: GitHub Actions is in a major outage, so remote CI has not run.** `deno task ci` passes locally (783 passed, 0 failed) — verified independently by the planning seat, not just reported by the implementer. Do not merge until checks can actually execute.

## The problem

Extracted candidates classify as `firstExtractedKnopWeave`, and the gate required exactly `firstPayloadWeave`. They fell through to the per-candidate recursive loop: at N=1,700 that meant `payloadBatchCandidates=0`, **1,445,850 candidate-cache hits** in a triangular pattern, and a **3.79 GiB peak against V8's ~4.09 GiB ceiling**.

## Result — measured like-for-like

The implementer measured on `versioned` history; the 3.79 GiB baseline was **current-only**, so I re-measured on the baseline's own configuration before accepting the numbers:

| N | before | after | wall before → after |
|---:|---:|---:|---|
| 500 | 1.45 GiB | **246 MiB** | 32.23s → 1.68s |
| 1,000 | 2.79 GiB | **340 MiB** | 1m55.60s → 3.42s |
| 1,700 | **3.79 GiB** | **377 MiB** | 5m09.98s → 5.36s |

Growth from N=500 to N=1,700 is **1.53× for 3.4× cardinality** — sublinear. The reduction *widens* with N, which is the signature of removing a quadratic rather than shaving a constant.

Ruled target was under 1.5 GiB at N=1,700 with growth no worse than linear. Met with ~4× margin.

## Widening the gate was not enough

Worth recording, because it's the non-obvious part. The first attempt still hit 1,078,900 KiB at N=500 — per-candidate full-MeshInventory plans — and then 1,123,436 KiB at N=1,000, because policy validation snapshotted every artifact for every candidate. **Two separate quadratic sources**, both of which had to go: a single-pass inventory renderer, and candidate-local policy equivalence for extracted batches.

## Scope discipline

The new `detectUntargetedFirstBatchSlice` admits a set only when it is untargeted, non-overwrite, larger than one, and **homogeneous** — every candidate the same slice. Mixed sets fail the homogeneity check and keep the sequential path, with a regression test proving mixed sets take three sequential planning iterations and recursive extracted sets take two, with no batch phase.

Fail-on-old recorded for both new tests: `"The current local weave slice supports exactly one weave candidate; found 2"`, and `payloadBatchCandidates` asserting 0 vs 3.

Page generation was explicitly **out of scope** — it is separately carved, still peaks near 3.7 GiB, and no viability claim for extract→weave→generate rests on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for batching compatible first extracted-Knop weaving operations.
  - Batched results now maintain canonical ordering, shared inventory progression, and consolidated history and metadata.
  - Resource pages and inventory entries are generated consistently for each woven item.

- **Bug Fixes**
  - Improved validation and clearer candidate-specific error reporting for batched operations.
  - Preserved source content and stable regeneration across complex pending and recursive weaving scenarios.

- **Performance**
  - Improved memory monitoring and caching during large or pending-heavy weaving operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->