### PR TITLE
fix(weave): render the inventory history index from actual progression (also repairs main)

### DIFF
--- a/src/core/weave/weave.ts
+++ b/src/core/weave/weave.ts
@@ -709,6 +709,7 @@ function planUntargetedFirstExtractedKnopBatchWeave(
       assertCurrentKnopInventoryBaseShape(
         meshBase,
         candidate.currentKnopInventoryTurtle,
+        designatorPath,
         knopPath,
       );
       if (
@@ -1767,23 +1768,16 @@ function planFirstExtractedKnopWeave(
         contents: exactSourceRegistryTurtle,
       }]),
       ...(meshInventoryProgression === undefined ||
+          wovenMeshInventoryTurtle === undefined ||
           !includeSharedMeshInventoryFiles
         ? []
         : [{
-          path: "_mesh/_inventory/_history001/index.html",
-          contents: renderArtifactHistoryIndexPage(meshBase, {
-            pagePath: "_mesh/_inventory/_history001/index.html",
-            description:
-              "Resource page for the current explicit history of the MeshInventory artifact.",
-            artifactLabel: "Inventory artifact",
-            workingLocalRelativePath: "_mesh/_inventory/inventory.ttl",
-            states: [
-              { segment: "_s0001", latest: false },
-              { segment: "_s0002", latest: false },
-              { segment: "_s0003", latest: false },
-              { segment: "_s0004", latest: true },
-            ],
-          }),
+          path: `${meshInventoryProgression.historyPath}/index.html`,
+          contents: renderProgressedMeshInventoryHistoryIndexPage(
+            meshBase,
+            wovenMeshInventoryTurtle,
+            meshInventoryProgression,
+          ),
         }]),
       ...(meshInventoryProgression === undefined ||
           !includeSharedMeshInventoryFiles
@@ -1801,6 +1795,14 @@ function planFirstExtractedKnopWeave(
       meshInventoryProgression,
       { knopMetadataHistoryPolicy, knopInventoryHistoryPolicy },
     ),
+    ...(meshInventoryProgression === undefined ||
+        !includeSharedMeshInventoryFiles
+      ? {}
+      : {
+        regeneratedPagePaths: [
+          `${meshInventoryProgression.historyPath}/index.html`,
+        ],
+      }),
   };
 }
 

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -3970,6 +3970,62 @@ Deno.test("planWeave renders the extracted bob woven slice", async () => {
   assertStringIncludes(bobPage?.contents ?? "", "<h1>bob</h1>");
 });
 
+Deno.test("planWeave derives a sequential MeshInventory history index through a named fifth state", async () => {
+  const input = await createExtractedBobAndCarolBatchInput();
+  const bobCandidate = input.weaveableKnops.find((candidate) =>
+    candidate.designatorPath === "bob"
+  )!;
+  const carolCandidate = input.weaveableKnops.find((candidate) =>
+    candidate.designatorPath === "carol"
+  )!;
+  const bobPlan = planWeave({
+    ...input,
+    request: { targets: [{ designatorPath: "bob" }] },
+    weaveableKnops: [bobCandidate],
+  });
+  const currentMeshInventoryTurtle =
+    bobPlan.updatedFiles.find((file) =>
+      file.path === "_mesh/_inventory/inventory.ttl"
+    )!.contents;
+  const currentMeshMetadataTurtle = bobPlan.updatedFiles.find((file) =>
+    file.path === "_mesh/_meta/meta.ttl"
+  )!.contents.replace(
+    '  sflo:nextStateOrdinal "5"^^xsd:nonNegativeInteger .',
+    `  sflo:nextStateOrdinal "5"^^xsd:nonNegativeInteger ;
+  sfcfg:hasNextStateSegmentHint "release-5" .`,
+  );
+
+  const carolPlan = planWeave({
+    ...input,
+    request: { targets: [{ designatorPath: "carol" }] },
+    currentMeshInventoryTurtle,
+    currentMeshMetadataTurtle,
+    weaveableKnops: [carolCandidate],
+  });
+  const historyIndexPath = "_mesh/_inventory/_history001/index.html";
+  const historyIndex =
+    carolPlan.updatedFiles.find((file) => file.path === historyIndexPath)!
+      .contents;
+
+  for (
+    const stateSegment of [
+      "_s0001",
+      "_s0002",
+      "_s0003",
+      "_s0004",
+      "release-5",
+    ]
+  ) {
+    assertStringIncludes(historyIndex, `href="./${stateSegment}"`);
+  }
+  assertFalse(historyIndex.includes('href="./_s0005"'));
+  assertStringIncludes(
+    historyIndex,
+    '<a href="./release-5">release-5</a> (latest)',
+  );
+  assertEquals(carolPlan.regeneratedPagePaths, [historyIndexPath]);
+});
+
 Deno.test("planWeave batches reverse-order untargeted extracted Knops with one canonical MeshInventory progression", async () => {
   const plan = planWeave(await createExtractedBobAndCarolBatchInput());
 

--- a/src/runtime/weave/version_execution.ts
+++ b/src/runtime/weave/version_execution.ts
@@ -533,6 +533,8 @@ export async function prepareVersionExecution(
   const createdPaths = new Set<string>();
   const updatedFileByPath = new Map<string, PlannedFile>();
   const updatedPathOrder: string[] = [];
+  const regeneratedPagePaths: string[] = [];
+  const regeneratedPagePathSet = new Set<string>();
   const versionedDesignatorPaths: string[] = [];
 
   while (remainingDesignatorPaths.length > 0) {
@@ -656,6 +658,12 @@ export async function prepareVersionExecution(
       }
       updatedFileByPath.set(file.path, file);
     }
+    for (const path of nextPlan.regeneratedPagePaths ?? []) {
+      if (!regeneratedPagePathSet.has(path)) {
+        regeneratedPagePaths.push(path);
+        regeneratedPagePathSet.add(path);
+      }
+    }
 
     versionedDesignatorPaths.push(...nextPlan.versionedDesignatorPaths);
     applyPlannedFilesToOverlay(workspaceRoot, overlay, nextPlan.createdFiles);
@@ -688,6 +696,7 @@ export async function prepareVersionExecution(
     createdFiles,
     ...(createdBinaryFiles.length > 0 ? { createdBinaryFiles } : {}),
     updatedFiles: updatedPathOrder.map((path) => updatedFileByPath.get(path)!),
+    ...(regeneratedPagePaths.length === 0 ? {} : { regeneratedPagePaths }),
   };
 
   timing?.setField("cachedReadFiles", overlay.readCount);

--- a/tests/scripts/pending_heavy_mesh_test.ts
+++ b/tests/scripts/pending_heavy_mesh_test.ts
@@ -190,6 +190,115 @@ Deno.test("untargeted extracted candidates use one instrumented coherent batch a
   );
 });
 
+Deno.test("sequential extracted versions regenerate a named MeshInventory history index from settled states", async () => {
+  const meshRoot = await createTestTmpDir(
+    "weave-pending-heavy-sequential-history-index-",
+  );
+  const generated = await generatePendingHeavyMesh({
+    outputPath: meshRoot,
+    count: 4,
+    meshInventoryHistoryPolicy: "versioned",
+    sourceDesignatorPath: "catalog/source",
+  });
+
+  for (const designatorPath of generated.extractedDesignatorPaths.slice(0, 3)) {
+    await executeVersion({
+      meshRoot,
+      request: { targets: [{ designatorPath }] },
+    });
+  }
+
+  const metadataPath = join(meshRoot, "_mesh/_meta/meta.ttl");
+  const metadataBeforeNamedProgression = await Deno.readTextFile(metadataPath);
+  const metadataWithNamedProgression = metadataBeforeNamedProgression
+    .replace(
+      "@prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .",
+      `@prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .
+@prefix sfcfg: <https://semantic-flow.github.io/sflo/config/> .`,
+    )
+    .replace(
+      '  sflo:nextStateOrdinal "6"^^xsd:nonNegativeInteger .',
+      `  sflo:nextStateOrdinal "6"^^xsd:nonNegativeInteger ;
+  sfcfg:hasNextStateSegmentHint "release-6" .`,
+    );
+  assert(
+    metadataWithNamedProgression !== metadataBeforeNamedProgression,
+    metadataBeforeNamedProgression,
+  );
+  await Deno.writeTextFile(metadataPath, metadataWithNamedProgression);
+
+  const finalDesignatorPath = generated.extractedDesignatorPaths[3]!;
+  const localPathPolicy = await loadOperationalLocalPathPolicy(meshRoot);
+  const timing = new RecordingRuntimeTiming();
+  const prepared = await prepareVersionExecution(
+    meshRoot,
+    normalizeVersionRequest({
+      targets: [{ designatorPath: finalDesignatorPath }],
+    }).targets,
+    localPathPolicy,
+    false,
+    undefined,
+    undefined,
+    timing,
+  );
+  assertEquals(timing.phaseCount("prepare.planPayloadBatch"), 0);
+  assertEquals(timing.phaseCount("prepare.loop.planVersion"), 1);
+
+  const versioned = await executeVersion({
+    meshRoot,
+    request: { targets: [{ designatorPath: finalDesignatorPath }] },
+  });
+  const historyIndexPath = "_mesh/_inventory/_history001/index.html";
+  const historyIndexAbsolutePath = join(meshRoot, historyIndexPath);
+  const historyIndex = await Deno.readTextFile(historyIndexAbsolutePath);
+  const pageStateSegments = [
+    ...historyIndex.matchAll(
+      /<summary class="wf-history-node-header"><a href="[^"]+\/_history001\/([^"/]+)">([^<]+)<\/a><\/summary>/g,
+    ),
+  ].filter((match) => match[1] === match[2]).map((match) => match[1]!).sort();
+  const diskStateSegments: string[] = [];
+  for await (
+    const entry of Deno.readDir(
+      join(meshRoot, "_mesh/_inventory/_history001"),
+    )
+  ) {
+    if (entry.isDirectory) {
+      diskStateSegments.push(entry.name);
+    }
+  }
+  diskStateSegments.sort();
+
+  assertEquals(pageStateSegments, diskStateSegments);
+  assertEquals(pageStateSegments, [
+    "_s0001",
+    "_s0002",
+    "_s0003",
+    "_s0004",
+    "_s0005",
+    "release-6",
+  ]);
+  assertEquals(prepared.plan.regeneratedPagePaths, [historyIndexPath]);
+  assert(versioned.updatedPaths.includes(historyIndexPath));
+
+  const digestAfterVersion = await sha256(
+    await Deno.readFile(historyIndexAbsolutePath),
+  );
+  const generatedAfterVersion = await executeGenerate({
+    meshRoot,
+    now: () => new Date("2026-08-07T12:00:00.000Z"),
+  });
+  assertEquals(
+    generatedAfterVersion.updatedPaths.filter((path) =>
+      path === historyIndexPath
+    ),
+    [],
+  );
+  assertEquals(
+    await sha256(await Deno.readFile(historyIndexAbsolutePath)),
+    digestAfterVersion,
+  );
+});
+
 Deno.test("untargeted multi-candidate extracted batch restructures a current-only MeshInventory once", async () => {
   const meshRoot = await createTestTmpDir(
     "weave-pending-heavy-current-only-extracted-batch-",


### PR DESCRIPTION
## ⚠️ This repairs a broken `main` — please merge promptly

**`main` does not currently type-check.** Merging #41 and #42 produced a **semantic merge conflict** that git resolved cleanly and that neither PR's CI could have caught:

- **#42** added a `designatorPath` parameter to `assertCurrentKnopInventoryBaseShape`
- **#41** independently added a new *call site* to that same function

Each branch was green against a `main` that lacked the other's change. Textually there was no conflict, so both showed `MERGEABLE / CLEAN`. The merge result fails with `Expected 4 arguments, but got 3`.

**The released `v0.7.0` tag is not affected** — verified it type-checks clean; it predates both merges. Nothing published is broken.

That's my error: I merged two PRs touching the same function without re-running CI against the merge result. "Each PR is green" is not the same claim as "the merge is green," and GitHub's mergeability check only speaks to text.

## The actual bite

The sequential weave path rendered `_mesh/_inventory/_history001/index.html` from a **literally hardcoded** `_s0001`–`_s0004` state list, so the page didn't describe the mesh being woven. This shipped in v0.7.0.

Reproduction on the pre-fix tree — page claimed:

```
["_s0001", "_s0002"]
```

while disk held:

```
["_s0001", "_s0002", "_s0003", "_s0004", "_s0005", "release-6"]
```

`planFirstExtractedKnopWeave` now derives the list from the progressed inventory RDF and emits the **same** exact-page regeneration marker the batch path already used — no second mechanism. The hardcoded list is gone from production source; two singleton `_s0001` arrays remain for newly created histories that genuinely have one state. No other progressing history index shares the defect.

## Tests built to defeat how this hid

The previous test missed it two ways, both now closed: it called `executeWeave`, whose internal generate phase repaired the page *before* the assertion, and it excluded `.html` from digest comparison. This one asserts at the `executeVersion` boundary and includes HTML.

Coverage deliberately includes **more than four states**, so a four-entry hardcoded list can't pass by coincidence, and a **named** fifth state (`release-6`), so an assumed `_s0005` can't either.

## Release note material

Generated bytes change for sequential versioned-MeshInventory weaves. Meshes that already ran `generate` had converged to these semantics; stale ones aren't retroactively modified. This is a **user-visible output correctness fix** for v0.8.0, not internal cleanup.

`deno task ci` green — verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)