### PR TITLE
fix(weave): stop deleting settled inventory facts during generation

### DIFF
--- a/src/core/weave/resource_page_policy.ts
+++ b/src/core/weave/resource_page_policy.ts
@@ -141,92 +141,19 @@ export function listGeneratedResourcePagePaths(
 export function filterResourcePageFactsFromInventoryTurtle(
   input: FilterResourcePageFactsInput,
 ): string {
-  if (
-    input.config === undefined &&
-    !hasResourcePageGenerationPolicyOverrides(input.policies)
-  ) {
-    return input.inventoryTurtle;
-  }
-
-  const quads = parseInventoryQuads(
-    input.meshBase,
-    input.inventoryTurtle,
-    input.parseErrorMessage,
-  );
-  const artifactRoles = collectArtifactRoles(input.meshBase, quads);
-  const ownerArtifacts = collectOwnerArtifacts(
-    input.meshBase,
-    quads,
-    artifactRoles,
-  );
-  const disallowedPagePaths = new Set<string>();
-
-  for (const quad of quads) {
-    if (
-      quad.predicate.value !== SFLO_HAS_RESOURCE_PAGE_IRI ||
-      quad.object.termType !== "NamedNode"
-    ) {
-      continue;
-    }
-
-    const subjectPath = tryToMeshPath(input.meshBase, quad.subject.value);
-    const pagePath = tryToMeshPath(input.meshBase, quad.object.value);
-    if (
-      subjectPath === undefined ||
-      pagePath === undefined ||
-      !isResourcePagePath(pagePath)
-    ) {
-      continue;
-    }
-    if (
-      !shouldGenerateResourcePageForSubject(
-        subjectPath,
-        artifactRoles,
-        ownerArtifacts,
-        input,
-      )
-    ) {
-      disallowedPagePaths.add(pagePath);
-    }
-  }
-
-  if (disallowedPagePaths.size === 0) {
-    return input.inventoryTurtle;
-  }
-
-  return removeResourcePagePaths(input.inventoryTurtle, disallowedPagePaths);
+  // Generation policy selects derived HTML bytes; it is not an implicit
+  // inventory-retraction mode.
+  return input.inventoryTurtle;
 }
 
 export function filterResourcePageFactsFromPlannedFiles(
-  meshBase: string,
+  _meshBase: string,
   files: readonly PlannedFile[],
-  policies?: WeaveResourcePageGenerationPolicies,
-  explicitRequest = false,
-  config?: ResourcePageGenerationConfig,
+  _policies?: WeaveResourcePageGenerationPolicies,
+  _explicitRequest = false,
+  _config?: ResourcePageGenerationConfig,
 ): readonly PlannedFile[] {
-  if (
-    config === undefined && !hasResourcePageGenerationPolicyOverrides(policies)
-  ) {
-    return files;
-  }
-
-  return files.map((file) => {
-    if (!isInventoryTurtlePath(file.path)) {
-      return file;
-    }
-    return {
-      ...file,
-      contents: filterResourcePageFactsFromInventoryTurtle({
-        meshBase,
-        inventoryTurtle: file.contents,
-        parseErrorMessage:
-          `Could not parse ${file.path} while applying ResourcePage generation policy.`,
-        config,
-        policies,
-        explicitRequest,
-      }),
-    };
-  });
+  return files;
 }
 
 function parseInventoryQuads(
@@ -418,82 +345,6 @@ function isHistoricalStatePredicate(predicateIri: string): boolean {
 
 function isResourcePagePath(path: string): boolean {
   return path === "index.html" || path.endsWith("/index.html");
-}
-
-function isInventoryTurtlePath(path: string): boolean {
-  return path === "_mesh/_inventory/inventory.ttl" ||
-    path.endsWith("/_inventory/inventory.ttl") ||
-    path.endsWith("/ttl/inventory.ttl");
-}
-
-function removeResourcePagePaths(
-  turtle: string,
-  pagePaths: ReadonlySet<string>,
-): string {
-  const blocks = turtle.trimEnd().split("\n\n");
-  const filteredBlocks = blocks.flatMap((block) => {
-    const subject = parseSubjectPath(block);
-    if (subject !== undefined && pagePaths.has(subject)) {
-      return [];
-    }
-
-    const lines = block.split("\n");
-    const filteredLines = lines.filter((line) =>
-      !isDisallowedResourcePageFact(line, pagePaths)
-    );
-    if (filteredLines.length === lines.length) {
-      return [block];
-    }
-
-    const normalizedBlock = normalizeTrailingPredicate(filteredLines);
-    return normalizedBlock === undefined ? [] : [normalizedBlock];
-  });
-
-  return `${filteredBlocks.join("\n\n")}\n`;
-}
-
-function parseSubjectPath(block: string): string | undefined {
-  const firstLine = block.split("\n", 1)[0]?.trim();
-  const match = firstLine?.match(/^<([^>]+)>/);
-  return match?.[1];
-}
-
-function isDisallowedResourcePageFact(
-  line: string,
-  pagePaths: ReadonlySet<string>,
-): boolean {
-  const match = line.match(/\bsflo:hasResourcePage <([^>]+)> [.;]$/);
-  return match !== null && pagePaths.has(match[1]!);
-}
-
-function normalizeTrailingPredicate(
-  lines: readonly string[],
-): string | undefined {
-  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
-  const lastPredicateIndex = findLastIndex(
-    nonEmptyLines,
-    (line) => line.trimEnd().endsWith(";"),
-  );
-  if (lastPredicateIndex !== -1) {
-    nonEmptyLines[lastPredicateIndex] = nonEmptyLines[lastPredicateIndex]!
-      .replace(/;\s*$/, ".");
-  }
-
-  return nonEmptyLines.some((line) => line.trimEnd().endsWith("."))
-    ? nonEmptyLines.join("\n")
-    : undefined;
-}
-
-function findLastIndex<T>(
-  values: readonly T[],
-  predicate: (value: T) => boolean,
-): number {
-  for (let index = values.length - 1; index >= 0; index -= 1) {
-    if (predicate(values[index]!)) {
-      return index;
-    }
-  }
-  return -1;
 }
 
 function tryToMeshPath(meshBase: string, iri: string): string | undefined {

--- a/src/core/weave/resource_page_policy_test.ts
+++ b/src/core/weave/resource_page_policy_test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "@std/assert";
+import {
+  filterResourcePageFactsFromInventoryTurtle,
+  listGeneratedResourcePagePaths,
+  type ResourcePageGenerationConfig,
+} from "./resource_page_policy.ts";
+
+const MESH_BASE = "https://semantic-flow.github.io/mesh-test/";
+
+Deno.test("settled multi-page facts survive policy changes while their pages stop generating", () => {
+  const inventoryTurtle = `@base <${MESH_BASE}> .
+@prefix ex: <https://example.org/> .
+@prefix sflo: <https://semantic-flow.github.io/sflo/ontology/> .
+
+# Preserve these exact settled bytes, including unfamiliar facts and comments.
+<alice/data> a sflo:PayloadArtifact, sflo:DigitalArtifact ;
+  ex:carried "unchanged" ;
+  sflo:hasResourcePage <alice/data/index.html> ;
+  sflo:hasResourcePage <alice/data/print/index.html> .
+
+<alice/data/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+
+<alice/data/print/index.html> a sflo:ResourcePage, sflo:LocatedFile .
+`;
+  const generate = policyConfig("generate");
+  const suppress = policyConfig("suppress");
+
+  assertEquals(
+    listGeneratedResourcePagePaths({
+      meshBase: MESH_BASE,
+      inventoryTurtle,
+      parseErrorMessage: "Could not parse test inventory.",
+      config: generate,
+    }),
+    ["alice/data/index.html", "alice/data/print/index.html"],
+  );
+  assertEquals(
+    filterResourcePageFactsFromInventoryTurtle({
+      meshBase: MESH_BASE,
+      inventoryTurtle,
+      parseErrorMessage: "Could not parse test inventory.",
+      config: suppress,
+    }),
+    inventoryTurtle,
+  );
+  assertEquals(
+    listGeneratedResourcePagePaths({
+      meshBase: MESH_BASE,
+      inventoryTurtle,
+      parseErrorMessage: "Could not parse test inventory.",
+      config: suppress,
+    }),
+    [],
+  );
+});
+
+function policyConfig(
+  payloadPolicy: "generate" | "suppress",
+): ResourcePageGenerationConfig {
+  return {
+    resourcePageGenerationPolicyForArtifactRole(role) {
+      return role === "payload" ? payloadPolicy : "generate";
+    },
+  };
+}

--- a/src/core/weave/weave_test.ts
+++ b/src/core/weave/weave_test.ts
@@ -294,7 +294,7 @@ Deno.test("planMeshSupportResourcePages records initial mesh inventory progressi
   );
 });
 
-Deno.test("planMeshSupportResourcePages omits suppressed support ResourcePage facts", () => {
+Deno.test("planMeshSupportResourcePages keeps support ResourcePage facts when pages are suppressed", () => {
   const plan = planMeshSupportResourcePages({
     meshBase: "https://semantic-flow.github.io/mesh-sidecar-fantasy-rules/",
     currentMeshInventoryTurtle: sidecarMeshCreatedInventoryTurtle,
@@ -320,14 +320,25 @@ Deno.test("planMeshSupportResourcePages omits suppressed support ResourcePage fa
   });
 
   const inventory = plan.updatedFiles[0]?.contents ?? "";
-  assertFalse(inventory.includes("_mesh/_config/index.html"));
-  assertFalse(inventory.includes("_mesh/_config/_history001/index.html"));
-  assertFalse(
-    inventory.includes("_mesh/_config/_history001/_s0001/index.html"),
+  assertStringIncludes(
+    inventory,
+    "sflo:hasResourcePage <_mesh/_config/index.html>",
   );
   assertStringIncludes(
     inventory,
-    "sflo:hasWorkingLocatedFile <_mesh/_config/config.ttl> ;\n  sflo:hasArtifactHistory <_mesh/_config/_history001> ;",
+    "sflo:hasResourcePage <_mesh/_config/_history001/index.html>",
+  );
+  assertStringIncludes(
+    inventory,
+    "sflo:hasResourcePage <_mesh/_config/_history001/_s0001/index.html>",
+  );
+  assertStringIncludes(
+    inventory,
+    "sflo:hasWorkingLocatedFile <_mesh/_config/config.ttl> ;",
+  );
+  assertStringIncludes(
+    inventory,
+    "sflo:hasArtifactHistory <_mesh/_config/_history001> ;",
   );
   assertStringIncludes(
     inventory,
@@ -1893,7 +1904,7 @@ Deno.test("planWeave applies current-only KnopMetadata policy on the first paylo
   );
 });
 
-Deno.test("planWeave omits payload ResourcePage facts when payload pages are suppressed", () => {
+Deno.test("planWeave keeps payload ResourcePage facts when payload pages are suppressed", () => {
   const plan = planWeave({
     request: {
       targets: [{ designatorPath: "alice/data" }],
@@ -1923,14 +1934,25 @@ Deno.test("planWeave omits payload ResourcePage facts when payload pages are sup
   const meshInventory = plan.updatedFiles[0]?.contents ?? "";
   const knopInventory = plan.updatedFiles[1]?.contents ?? "";
 
-  assertFalse(meshInventory.includes("alice/data/index.html"));
-  assertFalse(knopInventory.includes("alice/data/index.html"));
-  assertFalse(knopInventory.includes("alice/data/_history001/index.html"));
-  assertFalse(
-    knopInventory.includes("alice/data/_history001/_s0001/index.html"),
+  assertStringIncludes(
+    meshInventory,
+    "sflo:hasResourcePage <alice/data/index.html>",
   );
-  assertFalse(
-    knopInventory.includes("alice/data/_history001/_s0001/ttl/index.html"),
+  assertStringIncludes(
+    knopInventory,
+    "sflo:hasResourcePage <alice/data/index.html>",
+  );
+  assertStringIncludes(
+    knopInventory,
+    "sflo:hasResourcePage <alice/data/_history001/index.html>",
+  );
+  assertStringIncludes(
+    knopInventory,
+    "sflo:hasResourcePage <alice/data/_history001/_s0001/index.html>",
+  );
+  assertStringIncludes(
+    knopInventory,
+    "sflo:hasResourcePage <alice/data/_history001/_s0001/ttl/index.html>",
   );
   assertStringIncludes(knopInventory, "alice/data/_knop/index.html");
   assertStringIncludes(knopInventory, "alice/data/_knop/_inventory/index.html");


### PR DESCRIPTION
Queue item 3, bite 2. A confirmed correctness defect: **ordinary page generation deleted settled inventory facts.**

## The defect

`filterResourcePageFactsFromInventoryTurtle` handed disallowed page paths to `removeResourcePagePaths`, which split the inventory Turtle on blank lines, **dropped whole subject blocks**, filtered individual fact lines, and reassembled the remainder as text.

Two violations stacked: it deleted settled facts at all — during a routine command, under no explicit mode — and it did so by string manipulation rather than RDF, the same class the append planner exists to replace.

It also cuts directly against the 2026-08-07 ruling that states must be retractable **explicitly**, precisely so PII exposure can be corrected. Silent deletion as a side effect of a config change is what that ruling guards against.

## The fix

Inventory Turtle and planned files are now preserved **byte-for-byte**; the deletion machinery is gone. HTML selection stays RDF-aware through `listGeneratedResourcePagePaths`, so a disallowed page simply isn't generated.

**Option (a) — retain the fact, stop generating — was chosen on evidence, not preference.** Verified that later planning treats retained page facts as settled state without testing HTML existence, that validation has no ResourcePage file-existence invariant, and that publication validation checks host readiness and path leakage rather than every `hasResourcePage` target.

**Named cost, accepted:** a retained fact whose page is no longer generated can leave a dangling published link. It breaks no Weave check, but it's a real consequence of preferring append-onlyish to deletion, and the honest resolution is an explicit repair/retraction mode — not silent removal.

## Fail-on-old

`0 passed | 1 failed | 824 filtered out`. The old code removed both page facts **and** both page subject blocks **and** rewrote the surviving `ex:carried` predicate terminator — collateral damage to an *unrelated* carried fact. That's the sharpest argument that string-based inventory editing had to go.

The new test asserts exact byte identity and covers two pages for one resource, since `hasResourcePage` is not single-valued (verified against the ontology).

## The audit found three more

I asked for every other place that can destroy settled inventory facts. Boarded on the append-onlyish note, ordered by exposure:

1. **`knop add-reference`** (`add_reference.ts:281`) — canonically rerenders the KnopInventory preserving only *known* support artifacts, so **unrelated carried facts are at live risk of loss**. Sharpest of the three; not merely a contract violation.
2. **MeshInventory renderers** (`mesh_inventory_renderers.ts:440`) — overwrite whole subject blocks.
3. **Later `knop create`** (`create.ts:780`) — replaces the `_mesh` block wholesale.

Default generation bytes are unchanged; only the previously-defective restrictive-policy path differs.

`deno task ci` green (825 tests) — verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource-page facts are now preserved in inventory Turtle output, even when resource-page generation is suppressed.
  * Planned files are no longer filtered based on resource-page generation settings.
  * Created resource-page output remains correctly omitted when suppression is enabled.

* **Tests**
  * Added coverage for preserving inventory facts and validating generated paths under supported policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->